### PR TITLE
[RDK-45371] Moving mock function definition to cpp file and added new…

### DIFF
--- a/unit_tests/L1_testing/mocks/ContainerId.h
+++ b/unit_tests/L1_testing/mocks/ContainerId.h
@@ -45,125 +45,19 @@ public:
     ContainerId& operator=(ContainerId&&) = default;
     ~ContainerId() = default;
 
-    static void setImpl(ContainerIdImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static ContainerId* getInstance()
-    {
-        static ContainerId* instance = nullptr;
-        if(nullptr == instance)
-        {
-           instance = new ContainerId();
-        }
-        return instance;
-    }
-
-    static bool isValid()
-    {
-       return impl->isValid();
-    }
-
-    const std::string& str() const
-    {
-        return mId;
-    }
-
-    static const char* c_str()
-    {
-        return impl->c_str();
-    }
-
-    static bool isValidContainerId(const std::string& id)
-    {
-        if (id.empty() || (id.size() > 128))
-        {
-            return false;
-        }
-
-        unsigned alphaCount = 0;
-        for (const char c : id)
-        {
-            if (!isalnum(c) && (c != '.') && (c != '-') && (c != '_'))
-            {
-                return false;
-            }
-
-            if (isalpha(c))
-            {
-                alphaCount++;
-            }
-        }
-
-        if (id.find("..") != std::string::npos)
-        {
-           return false;
-        }
-
-        return (alphaCount > 0);
-   }
-
-
-    static ContainerId create(const std::string& s)
-    {
-       std::string str(s);
-       ContainerId id;
-
-      if (isValidContainerId(str))
-      {
-         id.mId.swap(str);
-      }
-
-       return id;
-    }
-
-   static ContainerId create(const char* s)
-   {
-      std::string str(s);
-      ContainerId id;
-
-      if (isValidContainerId(str))
-      {
-         id.mId.swap(str);
-      }
-
-      return id;
-   }
-
-   static ContainerId create(const char* s, size_t n)
-   {
-      std::string str(s, n);
-      ContainerId id;
-
-      if (isValidContainerId(str))
-      {
-         id.mId.swap(str);
-      }
-
-     return id;
-   }
-
-    bool operator==(const ContainerId& rhs) const
-    {
-        return mId == rhs.mId;
-    }
-
-    bool operator!=(const ContainerId& rhs) const
-    {
-        return mId != rhs.mId;
-    }
-
-    bool operator<(const ContainerId& rhs) const
-    {
-        return mId < rhs.mId;
-    }
-
-    bool operator>(const ContainerId& rhs) const
-    {
-        return mId > rhs.mId;
-    }
-
+    static void setImpl(ContainerIdImpl* newImpl);
+    static ContainerId* getInstance();
+    static bool isValid();
+    const std::string& str() const;
+    static const char* c_str();
+    static bool isValidContainerId(const std::string& id);
+    static ContainerId create(const std::string& s);
+    static ContainerId create(const char* s);
+    static ContainerId create(const char* s, size_t n);
+    bool operator==(const ContainerId& rhs) const;
+    bool operator!=(const ContainerId& rhs) const;
+    bool operator<(const ContainerId& rhs) const;
+    bool operator>(const ContainerId& rhs) const;
 
  };
 

--- a/unit_tests/L1_testing/mocks/ContainerIdMock.cpp
+++ b/unit_tests/L1_testing/mocks/ContainerIdMock.cpp
@@ -1,0 +1,143 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "ContainerIdMock.h"
+
+void ContainerId::setImpl(ContainerIdImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+ContainerId* ContainerId::getInstance()
+{
+    static ContainerId* instance = nullptr;
+    if(nullptr == instance)
+    {
+       instance = new ContainerId();
+    }
+    return instance;
+}
+
+bool ContainerId::isValid()
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->isValid();
+}
+
+const std::string& ContainerId::str() const
+{
+    return mId;
+}
+
+const char* ContainerId::c_str()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->c_str();
+}
+
+bool ContainerId::isValidContainerId(const std::string& id)
+{
+    if (id.empty() || (id.size() > 128))
+    {
+        return false;
+    }
+
+    unsigned alphaCount = 0;
+    for (const char c : id)
+    {
+        if (!isalnum(c) && (c != '.') && (c != '-') && (c != '_'))
+        {
+            return false;
+        }
+
+        if (isalpha(c))
+        {
+            alphaCount++;
+        }
+    }
+
+    if (id.find("..") != std::string::npos)
+    {
+       return false;
+    }
+
+    return (alphaCount > 0);
+}
+
+
+ContainerId ContainerId::create(const std::string& s)
+{
+   std::string str(s);
+   ContainerId id;
+
+  if (isValidContainerId(str))
+  {
+     id.mId.swap(str);
+  }
+
+   return id;
+}
+
+ContainerId ContainerId::create(const char* s)
+{
+  std::string str(s);
+  ContainerId id;
+
+  if (isValidContainerId(str))
+  {
+     id.mId.swap(str);
+  }
+
+  return id;
+}
+
+ContainerId ContainerId::create(const char* s, size_t n)
+{
+  std::string str(s, n);
+  ContainerId id;
+
+  if (isValidContainerId(str))
+  {
+     id.mId.swap(str);
+  }
+
+ return id;
+}
+
+bool ContainerId::operator==(const ContainerId& rhs) const
+{
+    return mId == rhs.mId;
+}
+
+bool ContainerId::operator!=(const ContainerId& rhs) const
+{
+    return mId != rhs.mId;
+}
+
+bool ContainerId::operator<(const ContainerId& rhs) const
+{
+    return mId < rhs.mId;
+}
+
+bool ContainerId::operator>(const ContainerId& rhs) const
+{
+    return mId > rhs.mId;
+}
+

--- a/unit_tests/L1_testing/mocks/DaemonDobbyManagerTest.h
+++ b/unit_tests/L1_testing/mocks/DaemonDobbyManagerTest.h
@@ -16,29 +16,26 @@
 # limitations under the License.
 */
 
-#include "DobbyConfigMock.h" 
-
-#include "NetfilterMock.h"
-
-#include "DobbyRootfsMock.h"
-
-#include "DobbyStatsMock.h"
-
+#include "DobbyStreamMock.h"
+#include "DobbyRdkPluginUtilsMock.h"
 #include "DobbyLoggerMock.h"
-
 #include "DobbyRunCMock.h"
-
-#include "DobbyBundleMock.h"
-
+#include "DobbyManager.h"
 #include "DobbyContainerMock.h"
-
 #include "DobbyRdkPluginManagerMock.h"
-
-#include "DobbySpecConfigMock.h"
-
-#include "DobbyBundleConfigMock.h"
-
-#include "IpcFileDescriptorMock.h"
-
 #include "DobbyStartStateMock.h"
+#include "DobbyRootfsMock.h"
+#include "DobbySpecConfigMock.h"
+#include "DobbyBundleMock.h"
+#include "DobbyConfigMock.h"
+#include "DobbyBundleConfigMock.h"
+#include "IDobbySettingsMock.h"
+#include "IDobbyIPCUtilsMock.h"
+#include "IDobbyUtilsMock.h"
+#include "IDobbyEnvMock.h"
+#include "IAsyncReplySenderMock.h"
+#include "ContainerIdMock.h"
+#include "DobbyFileAccessFixerMock.h"
+#include "DobbyLegacyPluginManagerMock.h"
+#include "DobbyStats.h"
 

--- a/unit_tests/L1_testing/mocks/DobbyBundle.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundle.h
@@ -31,6 +31,7 @@ public:
 
     virtual void setPersistence(bool persist) = 0;
     virtual bool isValid() const = 0;
+    virtual const std::string& path() const = 0;
 
 };
 
@@ -54,30 +55,10 @@ public:
     const std::string& path() const;
 
 
-    static void setImpl(DobbyBundleImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyBundle* getInstance()
-    {
-        static DobbyBundle* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbyBundle();
-        }
-        return instance;
-    }
-
-    static void setPersistence(bool persist)
-    {
-        return impl->setPersistence(persist);
-    }
-
-    static bool isValid()
-    {
-        return impl->isValid();
-    }
+    static void setImpl(DobbyBundleImpl* newImpl);
+    static DobbyBundle* getInstance();
+    static void setPersistence(bool persist);
+    static bool isValid();
 };
 
 #endif // !defined(DOBBYBUNDLE_H)

--- a/unit_tests/L1_testing/mocks/DobbyBundleConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundleConfig.h
@@ -28,10 +28,10 @@ class DobbyBundleConfigImpl {
 public:
 
     virtual std::shared_ptr<rt_dobby_schema> config() const =0;
-
     virtual bool restartOnCrash() const =0;
-
     virtual bool writeConfigJson(const std::string& filePath) const = 0;
+    virtual const std::map<std::string, Json::Value>& rdkPlugins() const = 0;
+    virtual bool isValid() const = 0;
 
 };
 
@@ -42,44 +42,17 @@ protected:
 
 public:
 
-    DobbyBundleConfig(){}
-
+    DobbyBundleConfig();
     DobbyBundleConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const ContainerId& id,const std::string& bundlePath);
-
-    ~DobbyBundleConfig(){}
+    ~DobbyBundleConfig();
 
     bool isValid() const ;
     const std::map<std::string, Json::Value>& rdkPlugins() const ;
-
-    static void setImpl(DobbyBundleConfigImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyBundleConfig* getInstance()
-    {
-        static DobbyBundleConfig* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbyBundleConfig();
-        }
-        return instance;
-    }
-
-    static std::shared_ptr<rt_dobby_schema> config()
-    {
-        return impl->config();
-    }
-
-    static bool restartOnCrash()
-    {
-        return impl->restartOnCrash();
-    }
-
-    static bool writeConfigJson(const std::string& filePath)
-    {
-        return impl->writeConfigJson(filePath);
-    }
+    static void setImpl(DobbyBundleConfigImpl* newImpl);
+    static DobbyBundleConfig* getInstance();
+    static std::shared_ptr<rt_dobby_schema> config();
+    static bool restartOnCrash();
+    static bool writeConfigJson(const std::string& filePath);
 };
 
 

--- a/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.cpp
@@ -1,0 +1,83 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyBundleConfigMock.h"
+
+DobbyBundleConfig::DobbyBundleConfig()
+{
+}
+
+DobbyBundleConfig::DobbyBundleConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const ContainerId& id,const std::string& bundlePath)
+{
+}
+
+DobbyBundleConfig::~DobbyBundleConfig()
+{
+}
+
+void DobbyBundleConfig::setImpl(DobbyBundleConfigImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyBundleConfig* DobbyBundleConfig::getInstance()
+{
+    static DobbyBundleConfig* instance = nullptr;
+    if (nullptr == instance)
+    {
+        instance = new DobbyBundleConfig();
+    }
+    return instance;
+}
+
+std::shared_ptr<rt_dobby_schema> DobbyBundleConfig::config()
+{
+    EXPECT_NE(impl, nullptr);
+
+    return impl->config();
+}
+
+bool DobbyBundleConfig::restartOnCrash()
+{
+    EXPECT_NE(impl, nullptr);
+
+    return impl->restartOnCrash();
+}
+
+bool DobbyBundleConfig::writeConfigJson(const std::string& filePath)
+{
+    EXPECT_NE(impl, nullptr);
+
+    return impl->writeConfigJson(filePath);
+}
+
+const std::map<std::string, Json::Value>& DobbyBundleConfig::rdkPlugins() const
+{
+    EXPECT_NE(impl, nullptr);
+
+    return impl->rdkPlugins();
+}
+
+bool DobbyBundleConfig::isValid() const
+{
+    EXPECT_NE(impl, nullptr);
+
+    return impl->isValid();
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundleConfigMock.h
@@ -30,5 +30,7 @@ public:
     MOCK_METHOD(std::shared_ptr<rt_dobby_schema>, config, (), (const,override));
     MOCK_METHOD(bool, restartOnCrash, (), (const,override));
     MOCK_METHOD(bool, writeConfigJson, (const std::string& filePath), (const,override));
+    MOCK_METHOD(bool, isValid, (), (const,override));
+    MOCK_METHOD((const std::map<std::string, Json::Value>&), rdkPlugins, (), (const,override));
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyBundleMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyBundleMock.cpp
@@ -1,0 +1,57 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyBundleMock.h"
+
+void DobbyBundle::setImpl(DobbyBundleImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyBundle* DobbyBundle::getInstance()
+{
+    static DobbyBundle* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyBundle();
+    }
+    return instance;
+}
+
+void DobbyBundle::setPersistence(bool persist)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setPersistence(persist);
+}
+
+bool DobbyBundle::isValid()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->isValid();
+}
+
+const std::string& DobbyBundle::path() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->path();
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyBundleMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyBundleMock.h
@@ -29,4 +29,5 @@ public:
 
     MOCK_METHOD(void, setPersistence, (bool persist), (override));
     MOCK_METHOD(bool, isValid, (), (const,override));
+    MOCK_METHOD((const std::string&), path, (), (const,override));
 };

--- a/unit_tests/L1_testing/mocks/DobbyConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfig.h
@@ -42,10 +42,15 @@ public:
     virtual bool writeConfigJson(const std::string& filePath) const = 0;
     virtual const std::map<std::string, Json::Value>& rdkPlugins() const = 0;
     virtual std::shared_ptr<rt_dobby_schema> config() const = 0;
+    virtual bool changeProcessArgs(const std::string& command) = 0;
+    virtual bool addWesterosMount(const std::string& socketPath) = 0;
+    virtual bool addEnvironmentVar(const std::string& envVar) = 0;
+    virtual bool enableSTrace(const std::string& logsDir) = 0;
+    virtual std::string configJson() const = 0;
+
 #if defined(LEGACY_COMPONENTS)
     virtual std::string spec() const =0;
     virtual const std::map<std::string, Json::Value>& legacyPlugins() const = 0;
-
 #endif //defined(LEGACY_COMPONENTS)
 
 };
@@ -60,56 +65,21 @@ public:
     DobbyConfig(){}
     ~DobbyConfig(){}
 
-    bool changeProcessArgs(const std::string& command);
-    bool addWesterosMount(const std::string& socketPath);
-    bool addEnvironmentVar(const std::string& envVar);
-    bool enableSTrace(const std::string& logsDir);
-    const std::string configJson() const;
-
-    static void setImpl(DobbyConfigImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyConfig* getInstance()
-    {
-        static DobbyConfig* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbyConfig();
-        }
-        return instance;
-    }
-
-    static bool writeConfigJson(const std::string& filePath)
-    {
-        return impl->writeConfigJson(filePath);
-    }
-
-    static const std::map<std::string, Json::Value>& rdkPlugins()
-    {
-        return impl->rdkPlugins();
-    }
-
-    static const std::shared_ptr<rt_dobby_schema> config()
-    {
-        return impl->config();
-    }
+    static void setImpl(DobbyConfigImpl* newImpl);
+    static DobbyConfig* getInstance();
+    static bool writeConfigJson(const std::string& filePath);
+    static const std::map<std::string, Json::Value>& rdkPlugins();
+    static const std::shared_ptr<rt_dobby_schema> config();
+    static bool changeProcessArgs(const std::string& command);
+    static bool addWesterosMount(const std::string& socketPath);
+    static bool addEnvironmentVar(const std::string& envVar);
+    static bool enableSTrace(const std::string& logsDir);
+    static std::string configJson();
 
 #if defined(LEGACY_COMPONENTS)
-
-    static const std::string spec()
-    {
-        return impl->spec();
-    }
-
-    static const std::map<std::string, Json::Value>& legacyPlugins()
-    {
-        return impl->legacyPlugins();
-    }
-
+    static const std::string spec();
+    static const std::map<std::string, Json::Value>& legacyPlugins();
 #endif //defined(LEGACY_COMPONENTS)
-
 
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.cpp
@@ -1,0 +1,114 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <gmock/gmock.h>
+
+#include "DobbyConfigMock.h"
+
+void DobbyConfig::setImpl(DobbyConfigImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyConfig* DobbyConfig::getInstance()
+{
+    static DobbyConfig* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyConfig();
+    }
+    return instance;
+}
+
+bool DobbyConfig::writeConfigJson(const std::string& filePath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->writeConfigJson(filePath);
+}
+
+const std::map<std::string, Json::Value>& DobbyConfig::rdkPlugins()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->rdkPlugins();
+}
+
+const std::shared_ptr<rt_dobby_schema> DobbyConfig::config()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->config();
+}
+
+#if defined(LEGACY_COMPONENTS)
+
+const std::string DobbyConfig::spec()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->spec();
+}
+
+const std::map<std::string, Json::Value>& DobbyConfig::legacyPlugins()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->legacyPlugins();
+}
+
+bool DobbyConfig::changeProcessArgs(const std::string& command) 
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->changeProcessArgs(command);
+}
+
+bool DobbyConfig::addWesterosMount(const std::string& socketPath) 
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addWesterosMount(socketPath);
+}
+
+bool DobbyConfig::addEnvironmentVar(const std::string& envVar) 
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addEnvironmentVar(envVar);
+}
+
+bool DobbyConfig::enableSTrace(const std::string& logsDir) 
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->enableSTrace(logsDir);
+}
+
+std::string DobbyConfig::configJson()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->configJson();
+}
+
+
+#endif //defined(LEGACY_COMPONENTS)
+
+

--- a/unit_tests/L1_testing/mocks/DobbyConfigMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyConfigMock.h
@@ -30,6 +30,12 @@ public:
     MOCK_METHOD(bool, writeConfigJson, (const std::string& filePath), (const,override));
     MOCK_METHOD((std::map<std::string, Json::Value>&), rdkPlugins, (), (const,override));
     MOCK_METHOD((std::shared_ptr<rt_dobby_schema>), config, (), (const,override));
+    MOCK_METHOD(bool, changeProcessArgs, (const std::string& command), (override));
+    MOCK_METHOD(bool, addWesterosMount, (const std::string& socketPath), (override));
+    MOCK_METHOD(bool, addEnvironmentVar, (const std::string& envVar), (override));
+    MOCK_METHOD(bool, enableSTrace, (const std::string& logsDir), (override));
+    MOCK_METHOD(std::string, configJson, (), (const,override));
+
 #if defined(LEGACY_COMPONENTS)
     MOCK_METHOD(std::string, spec, (), (const,override));
     MOCK_METHOD((std::map<std::string, Json::Value>&), legacyPlugins, (), (const,override));

--- a/unit_tests/L1_testing/mocks/DobbyContainer.h
+++ b/unit_tests/L1_testing/mocks/DobbyContainer.h
@@ -34,11 +34,11 @@ class DobbyRdkPluginManager;
 
 class DobbyContainerImpl {
 public:
-
     virtual ~DobbyContainerImpl() = default;
-
     virtual void setRestartOnCrash(const std::list<int>& files) = 0;
     virtual void clearRestartOnCrash() = 0;
+    virtual bool shouldRestart(int statusCode) = 0;
+    virtual const std::list<int>& files() const = 0;
 };
 
 class DobbyContainer {
@@ -53,14 +53,6 @@ public:
     DobbyContainer(DobbyContainer&&) = delete;
     friend class DobbyManager;
 
-    DobbyContainer(): descriptor(0){}
-
-    DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle,const std::shared_ptr<const DobbyConfig>& _config,const std::shared_ptr<const DobbyRootfs>& _rootfs):descriptor(0){}
-
-    DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle,const std::shared_ptr<const DobbyConfig>& _config,const std::shared_ptr<const DobbyRootfs>& _rootfs,const std::shared_ptr<const DobbyRdkPluginManager>& _rdkPluginManager):descriptor(0){}
-
-    ~DobbyContainer(){}
-
     enum class State { Starting, Running, Stopping, Paused, Unknown } state;
     pid_t containerPid;
     const int32_t descriptor;
@@ -70,36 +62,21 @@ public:
     std::list<int> mFiles;
     bool hasCurseOfDeath;
     const std::shared_ptr<const DobbyRootfs> rootfs;
-    const std::list<int>& files() const;
 
-    bool shouldRestart(int statusCode);
+    DobbyContainer();
+    DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle,const std::shared_ptr<const DobbyConfig>& _config,const std::shared_ptr<const DobbyRootfs>& _rootfs);
+    DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle,const std::shared_ptr<const DobbyConfig>& _config,const std::shared_ptr<const DobbyRootfs>& _rootfs,const std::shared_ptr<const DobbyRdkPluginManager>& _rdkPluginManager);
+    ~DobbyContainer();
+
+    static bool shouldRestart(int statusCode);
 
     std::string customConfigFilePath;
 
-    static void setImpl(DobbyContainerImpl* newImpl)
-    {
-         impl = newImpl;
-    }
-
-    static DobbyContainer* getInstance()
-    {
-        static DobbyContainer* instance = nullptr;
-        if (nullptr == instance)
-        {
-            instance = new DobbyContainer();
-        }
-        return instance;
-    }
-
-    static void setRestartOnCrash(const std::list<int>& files)
-    {
-        return impl->setRestartOnCrash(files);
-    }
-
-    static void clearRestartOnCrash()
-    {
-        return impl->clearRestartOnCrash();
-    }
+    static void setImpl(DobbyContainerImpl* newImpl);
+    static DobbyContainer* getInstance();
+    static void setRestartOnCrash(const std::list<int>& files);
+    static void clearRestartOnCrash();
+    static const std::list<int>& files();
 };
 
 #endif // DOBBYCONTAINER_H

--- a/unit_tests/L1_testing/mocks/DobbyContainerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyContainerMock.cpp
@@ -1,0 +1,92 @@
+
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyContainerMock.h"
+
+DobbyContainer::DobbyContainer(): descriptor(0)
+{
+}
+
+DobbyContainer::DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle,const std::shared_ptr<const DobbyConfig>& _config,const std::shared_ptr<const DobbyRootfs>& _rootfs):descriptor(0)
+{
+}
+
+DobbyContainer::DobbyContainer(const std::shared_ptr<const DobbyBundle>& _bundle,
+                               const std::shared_ptr<const DobbyConfig>& _config,
+                               const std::shared_ptr<const DobbyRootfs>& _rootfs,
+                               const std::shared_ptr<const DobbyRdkPluginManager>& _rdkPluginManager)
+    : descriptor(0)
+    , bundle(_bundle)
+    , config(_config)
+    , rootfs(_rootfs)
+    , rdkPluginManager(_rdkPluginManager)
+    , containerPid(-1)
+    , hasCurseOfDeath(false)
+    , state(State::Starting)
+{
+}
+
+DobbyContainer::~DobbyContainer()
+{
+}
+
+bool DobbyContainer::shouldRestart(int statusCode)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->shouldRestart(statusCode);
+}
+
+void DobbyContainer::setImpl(DobbyContainerImpl* newImpl)
+{
+     impl = newImpl;
+}
+
+DobbyContainer* DobbyContainer::getInstance()
+{
+    static DobbyContainer* instance = nullptr;
+    if (nullptr == instance)
+    {
+        instance = new DobbyContainer();
+    }
+    return instance;
+}
+
+void DobbyContainer::setRestartOnCrash(const std::list<int>& files)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setRestartOnCrash(files);
+}
+
+void DobbyContainer::clearRestartOnCrash()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->clearRestartOnCrash();
+}
+
+const std::list<int>& DobbyContainer::files()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->files();
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyContainerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyContainerMock.h
@@ -30,5 +30,6 @@ public:
     virtual ~DobbyContainerMock() = default;
     MOCK_METHOD(void, setRestartOnCrash, (const std::list<int>& files), (override));
     MOCK_METHOD(void, clearRestartOnCrash, (), (override));
-
+    MOCK_METHOD(bool, shouldRestart, (int statusCode), (override));
+    MOCK_METHOD((const std::list<int>&), files, (), (const, override));
 };

--- a/unit_tests/L1_testing/mocks/DobbyEnv.h
+++ b/unit_tests/L1_testing/mocks/DobbyEnv.h
@@ -43,46 +43,15 @@ protected:
 
 public:
 
-    DobbyEnv() {}
-    ~DobbyEnv() {}
-
-    DobbyEnv(const std::shared_ptr<const IDobbySettings>& settings){}
-    
-    static void setImpl(DobbyEnvImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyEnv* getInstance()
-    {
-        static DobbyEnv* instance = nullptr;
-        if(nullptr == instance)
-        {
-           instance = new DobbyEnv();
-        }
-        return instance;
-    }
-
-    static std::string workspaceMountPath()
-    {
-       return impl->workspaceMountPath();
-    }
-
-    static std::string flashMountPath()
-    {
-       return impl->flashMountPath();
-    }
-
-    static std::string pluginsWorkspacePath()
-    {
-       return impl->pluginsWorkspacePath();
-    }
-
-    static uint16_t platformIdent()
-    {
-       return impl->platformIdent();
-    }
-
+    DobbyEnv();
+    ~DobbyEnv();
+    DobbyEnv(const std::shared_ptr<const IDobbySettings>& settings);
+    static void setImpl(DobbyEnvImpl* newImpl);
+    static DobbyEnv* getInstance();
+    static std::string workspaceMountPath();
+    static std::string flashMountPath();
+    static std::string pluginsWorkspacePath();
+    static uint16_t platformIdent();
 };
 
 #endif // !defined(DOBBYENV_H)

--- a/unit_tests/L1_testing/mocks/DobbyEnvMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyEnvMock.cpp
@@ -1,0 +1,76 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyEnvMock.h"
+
+DobbyEnvImpl *DobbyEnv::impl = nullptr;
+
+DobbyEnv::DobbyEnv()
+{
+}
+
+DobbyEnv::~DobbyEnv()
+{
+}
+
+DobbyEnv::DobbyEnv(const std::shared_ptr<const IDobbySettings>& settings)
+{
+}
+
+void DobbyEnv::setImpl(DobbyEnvImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyEnv* DobbyEnv::getInstance()
+{
+    static DobbyEnv* instance = nullptr;
+    if(nullptr == instance)
+    {
+       instance = new DobbyEnv();
+    }
+    return instance;
+}
+
+std::string DobbyEnv::workspaceMountPath()
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->workspaceMountPath();
+}
+
+std::string DobbyEnv::flashMountPath()
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->flashMountPath();
+}
+
+std::string DobbyEnv::pluginsWorkspacePath()
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->pluginsWorkspacePath();
+}
+
+uint16_t DobbyEnv::platformIdent()
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->platformIdent();
+}

--- a/unit_tests/L1_testing/mocks/DobbyFileAccessFixer.h
+++ b/unit_tests/L1_testing/mocks/DobbyFileAccessFixer.h
@@ -1,0 +1,70 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyFileAccessFixer.h
+ *
+ */
+#ifndef DOBBYFILEACCESSFIXER_H
+#define DOBBYFILEACCESSFIXER_H
+
+#include <ftw.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+
+// -----------------------------------------------------------------------------
+/**
+ *  @class DobbyFileAccessFixer
+ *  @brief Utility object to fix the various incorrectly 'hardened' file
+ *  permissions.
+ *
+ *  The 'hardening' process continuously 'over hardens' various files to the
+ *  point where things become unusable.  This object is used to go through and
+ *  fix-up the files before launching the DobbyDaemon.
+ *
+ *  This method only has one method, fixIt() that applies all the know file
+ *  perms fixups.
+ *
+ *  Hopefully in the future we can remove all these hacks and have just the
+ *  correct perms from the start.
+ *
+ */
+class DobbyFileAccessFixerImpl
+{
+public:
+    virtual bool fixIt() const = 0;
+};
+
+class DobbyFileAccessFixer
+{
+protected:
+    static class DobbyFileAccessFixerImpl *impl;
+
+public:
+    DobbyFileAccessFixer();
+    ~DobbyFileAccessFixer();
+    static DobbyFileAccessFixer* getInstance();
+    static void setImpl(DobbyFileAccessFixerImpl* newImpl);
+
+public:
+    bool fixIt() const;
+};
+
+
+#endif // !defined(DOBBYFILEACCESSFIXER_H)

--- a/unit_tests/L1_testing/mocks/DobbyFileAccessFixerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyFileAccessFixerMock.cpp
@@ -1,0 +1,50 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyFileAccessFixerMock.h"
+
+DobbyFileAccessFixer::DobbyFileAccessFixer()
+{
+}
+
+DobbyFileAccessFixer::~DobbyFileAccessFixer()
+{
+}
+
+DobbyFileAccessFixer* DobbyFileAccessFixer::getInstance()
+{
+    static DobbyFileAccessFixer* instance = nullptr;
+    if (nullptr == instance)
+    {
+        instance = new DobbyFileAccessFixer();
+    }
+    return instance;
+}
+
+void DobbyFileAccessFixer::setImpl(DobbyFileAccessFixerImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+bool DobbyFileAccessFixer::fixIt() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->fixIt();
+}

--- a/unit_tests/L1_testing/mocks/DobbyFileAccessFixerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyFileAccessFixerMock.h
@@ -1,0 +1,33 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "DobbyFileAccessFixer.h"
+
+class DobbyFileAccessFixerMock : public DobbyFileAccessFixerImpl {
+
+public:
+
+    virtual ~DobbyFileAccessFixerMock() = default;
+
+    MOCK_METHOD(bool, fixIt, (), (const,override));
+};
+

--- a/unit_tests/L1_testing/mocks/DobbyIPCUtils.h
+++ b/unit_tests/L1_testing/mocks/DobbyIPCUtils.h
@@ -40,30 +40,13 @@ protected:
 
 public:
     DobbyIPCUtils(const std::string &systemDbusAddress,
-               const std::shared_ptr<AI_IPC::IIpcService> &systemIpcService){}
-    DobbyIPCUtils(){}
-    ~DobbyIPCUtils(){}
+               const std::shared_ptr<AI_IPC::IIpcService> &systemIpcService);
+    DobbyIPCUtils();
+    ~DobbyIPCUtils();
 
-    static void setImpl(DobbyIPCUtilsImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyIPCUtils* getInstance()
-    {
-        static DobbyIPCUtils* instance = nullptr;
-        if(nullptr == instance)
-        {
-            instance = new DobbyIPCUtils();
-        }
-        return instance;
-    }
-
-    static bool setAIDbusAddress(bool privateBus, const std::string &address)
-    {
-        return impl->setAIDbusAddress(privateBus,address);
-    }
-
+    static void setImpl(DobbyIPCUtilsImpl* newImpl);
+    static DobbyIPCUtils* getInstance();
+    static bool setAIDbusAddress(bool privateBus, const std::string &address);
 };
 
 #endif

--- a/unit_tests/L1_testing/mocks/DobbyIPCUtilsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyIPCUtilsMock.cpp
@@ -1,0 +1,54 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyIPCUtilsMock.h"
+
+DobbyIPCUtils::DobbyIPCUtils(const std::string &systemDbusAddress,
+           const std::shared_ptr<AI_IPC::IIpcService> &systemIpcService)
+{
+}
+
+DobbyIPCUtils::DobbyIPCUtils()
+{
+}
+
+DobbyIPCUtils::~DobbyIPCUtils()
+{
+}
+
+void DobbyIPCUtils::setImpl(DobbyIPCUtilsImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyIPCUtils* DobbyIPCUtils::getInstance()
+{
+    static DobbyIPCUtils* instance = nullptr;
+    if(nullptr == instance)
+    {
+        instance = new DobbyIPCUtils();
+    }
+    return instance;
+}
+
+bool DobbyIPCUtils::setAIDbusAddress(bool privateBus, const std::string &address)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setAIDbusAddress(privateBus,address);
+}

--- a/unit_tests/L1_testing/mocks/DobbyLegacyPluginManager.h
+++ b/unit_tests/L1_testing/mocks/DobbyLegacyPluginManager.h
@@ -1,0 +1,129 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyLegacyPluginManager.h
+ *
+ */
+
+#ifndef DOBBYLEGACYPLUGINMANAGER_H
+#define DOBBYLEGACYPLUGINMANAGER_H
+
+#if defined(RDK)
+#  include <json/json.h>
+#else
+#  include <jsoncpp/json.h>
+#endif
+
+#include <pthread.h>
+#include <sys/types.h>
+
+#include <map>
+#include <string>
+#include <memory>
+#include <future>
+
+#if defined(RDK)
+#   define DEFAULT_PLUGIN_PATH   "/usr/lib/plugins/dobby"
+#else
+#   define DEFAULT_PLUGIN_PATH   "/opt/libexec"
+#endif
+
+class ContainerId;
+class IDobbyPlugin;
+class IDobbyStartState;
+class IDobbyEnv;
+
+// -----------------------------------------------------------------------------
+class DobbyLegacyPluginManagerImpl
+{
+public:
+    virtual ~DobbyLegacyPluginManagerImpl() = default;
+
+    virtual void refreshPlugins(const std::string& path = std::string(DEFAULT_PLUGIN_PATH)) = 0;
+
+    virtual bool executePostConstructionHooks(const std::map<std::string, Json::Value>& plugins,
+                                      const ContainerId& id,
+                                      const std::shared_ptr<IDobbyStartState>& startupState,
+                                      const std::string& rootfsPath) const = 0;
+
+    virtual bool executePreStartHooks(const std::map<std::string, Json::Value>& plugins,
+                              const ContainerId& id,
+                              pid_t pid,
+                              const std::string& rootfsPath) const = 0;
+
+    virtual bool executePostStartHooks(const std::map<std::string, Json::Value>& plugins,
+                               const ContainerId& id,
+                               pid_t pid,
+                               const std::string& rootfsPath) const = 0;
+
+    virtual bool executePostStopHooks(const std::map<std::string, Json::Value>& plugins,
+                              const ContainerId& id,
+                              const std::string& rootfsPath) const = 0;
+
+    virtual bool executePreDestructionHooks(const std::map<std::string, Json::Value>& plugins,
+                                    const ContainerId& id,
+                                    const std::string& rootfsPath) const = 0;
+};
+/**
+ *  @class DobbyLegacyPluginManager
+ *  @brief Class that manages all the plugin hook libraries.
+ *
+ *  This class doesn't manage the system hooks, they are setup in the
+ *  DobbyManager class (we should probably change this ... TBD)
+ *
+ *  At creation time it loads all the plugin libraries from /opt/libexec.
+ *
+ */
+class DobbyLegacyPluginManager
+{
+protected:
+    static DobbyLegacyPluginManagerImpl *impl;
+public:
+    DobbyLegacyPluginManager();
+    DobbyLegacyPluginManager(const std::shared_ptr<IDobbyEnv>& env,
+                             const std::shared_ptr<IDobbyUtils>& utils,
+                             const std::string& path = std::string(DEFAULT_PLUGIN_PATH));
+    ~DobbyLegacyPluginManager();
+
+public:
+    static DobbyLegacyPluginManager* getInstance();
+    static void setImpl(DobbyLegacyPluginManagerImpl* newImpl);
+    static void refreshPlugins(const std::string& path = std::string(DEFAULT_PLUGIN_PATH));
+    static bool executePostConstructionHooks(const std::map<std::string, Json::Value>& plugins,
+                                      const ContainerId& id,
+                                      const std::shared_ptr<IDobbyStartState>& startupState,
+                                      const std::string& rootfsPath);
+    static bool executePreStartHooks(const std::map<std::string, Json::Value>& plugins,
+                              const ContainerId& id,
+                              pid_t pid,
+                              const std::string& rootfsPath);
+    static bool executePostStartHooks(const std::map<std::string, Json::Value>& plugins,
+                               const ContainerId& id,
+                               pid_t pid,
+                               const std::string& rootfsPath);
+    static bool executePostStopHooks(const std::map<std::string, Json::Value>& plugins,
+                              const ContainerId& id,
+                              const std::string& rootfsPath);
+    static bool executePreDestructionHooks(const std::map<std::string, Json::Value>& plugins,
+                                    const ContainerId& id,
+                                    const std::string& rootfsPath);
+};
+
+
+#endif // !defined(DOBBYLEGACYPLUGINMANAGER_H)

--- a/unit_tests/L1_testing/mocks/DobbyLegacyPluginManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyLegacyPluginManagerMock.cpp
@@ -1,0 +1,107 @@
+
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "IDobbyUtils.h"
+#include "DobbyLegacyPluginManagerMock.h"
+
+DobbyLegacyPluginManager::DobbyLegacyPluginManager()
+{
+}
+
+DobbyLegacyPluginManager::DobbyLegacyPluginManager(const std::shared_ptr<IDobbyEnv>& env,
+                                                   const std::shared_ptr<IDobbyUtils>& utils,
+                                                   const std::string& path /*= std::string(DEFAULT_PLUGIN_PATH)*/)
+{
+}
+
+DobbyLegacyPluginManager::~DobbyLegacyPluginManager()
+{
+}
+
+void DobbyLegacyPluginManager::refreshPlugins(const std::string& path /*= std::string(DEFAULT_PLUGIN_PATH)*/)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->refreshPlugins(path);
+}
+
+bool DobbyLegacyPluginManager::executePostConstructionHooks(const std::map<std::string, Json::Value>& plugins,
+                                  const ContainerId& id,
+                                  const std::shared_ptr<IDobbyStartState>& startupState,
+                                  const std::string& rootfsPath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->executePostConstructionHooks(plugins,id,startupState,rootfsPath);
+}
+
+bool DobbyLegacyPluginManager::executePreStartHooks(const std::map<std::string, Json::Value>& plugins,
+                          const ContainerId& id,
+                          pid_t pid,
+                          const std::string& rootfsPath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->executePreStartHooks(plugins,id,pid,rootfsPath);
+}
+
+bool DobbyLegacyPluginManager::executePostStartHooks(const std::map<std::string, Json::Value>& plugins,
+                           const ContainerId& id,
+                           pid_t pid,
+                           const std::string& rootfsPath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->executePostStartHooks(plugins,id,pid,rootfsPath);
+}
+
+bool DobbyLegacyPluginManager::executePostStopHooks(const std::map<std::string, Json::Value>& plugins,
+                          const ContainerId& id,
+                          const std::string& rootfsPath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->executePostStopHooks(plugins,id,rootfsPath);
+}
+
+bool DobbyLegacyPluginManager::executePreDestructionHooks(const std::map<std::string, Json::Value>& plugins,
+                                const ContainerId& id,
+                                const std::string& rootfsPath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->executePreDestructionHooks(plugins,id,rootfsPath);
+}
+
+DobbyLegacyPluginManager* DobbyLegacyPluginManager::getInstance()
+{
+    static DobbyLegacyPluginManager* instance = nullptr;
+    if (nullptr == instance)
+    {
+        instance = new DobbyLegacyPluginManager();
+    }
+    return instance;
+}
+
+void DobbyLegacyPluginManager::setImpl(DobbyLegacyPluginManagerImpl* newImpl)
+{
+    impl = newImpl;
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyLegacyPluginManagerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyLegacyPluginManagerMock.h
@@ -1,0 +1,52 @@
+
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "DobbyLegacyPluginManager.h"
+
+class DobbyLegacyPluginManagerMock : public DobbyLegacyPluginManagerImpl {
+
+public:
+
+    virtual ~DobbyLegacyPluginManagerMock() = default;
+    MOCK_METHOD(void, refreshPlugins, (const std::string& path), (override));
+    MOCK_METHOD(bool, executePostConstructionHooks, ((const std::map<std::string, Json::Value>& plugins),
+                                      const ContainerId& id,
+                                      const std::shared_ptr<IDobbyStartState>& startupState,
+                                      const std::string& rootfsPath), (const, override));
+    MOCK_METHOD(bool, executePreStartHooks, ((const std::map<std::string, Json::Value>& plugins),
+                              const ContainerId& id,
+                              pid_t pid,
+                              const std::string& rootfsPath), (const, override));
+    MOCK_METHOD(bool, executePostStartHooks, ((const std::map<std::string, Json::Value>& plugins),
+                              const ContainerId& id,
+                              pid_t pid,
+                              const std::string& rootfsPath), (const, override));
+    MOCK_METHOD(bool, executePostStopHooks, ((const std::map<std::string, Json::Value>& plugins),
+                              const ContainerId& id,
+                              const std::string& rootfsPath), (const, override));
+    MOCK_METHOD(bool, executePreDestructionHooks,( (const std::map<std::string, Json::Value>& plugins),
+                              const ContainerId& id,
+                              const std::string& rootfsPath), (const, override));
+
+};
+

--- a/unit_tests/L1_testing/mocks/DobbyLogger.h
+++ b/unit_tests/L1_testing/mocks/DobbyLogger.h
@@ -1,0 +1,61 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyLegacyPluginManager.h
+ *
+ */
+
+#ifndef DOBBYLOGGER_H
+#define DOBBYLOGGER_H
+
+#include <sys/types.h>
+
+#include "ContainerId.h"
+#include "IDobbyRdkLoggingPlugin.h"
+#include <IDobbySettings.h>
+
+class DobbyLoggerImpl {
+public:
+
+    virtual ~DobbyLoggerImpl() = default;
+
+    virtual bool StartContainerLogging(std::string containerId,pid_t runtimePid,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin) = 0;
+    virtual bool DumpBuffer(int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin) = 0;
+
+};
+
+class DobbyLogger {
+
+protected:
+    static DobbyLoggerImpl* impl;
+
+public:
+    DobbyLogger();
+    DobbyLogger(const std::shared_ptr<const IDobbySettings> &settings);
+    ~DobbyLogger();
+
+    static void setImpl(DobbyLoggerImpl* newImpl);
+    static DobbyLogger* getInstance();
+    static bool StartContainerLogging(std::string containerId,pid_t runtimePid,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin);
+    static bool DumpBuffer(int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin);
+};
+
+#endif // !defined(DOBBYLOGGER_H)
+
+

--- a/unit_tests/L1_testing/mocks/DobbyLoggerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyLoggerMock.cpp
@@ -1,0 +1,61 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyLoggerMock.h"
+
+DobbyLogger::DobbyLogger()
+{
+}
+
+DobbyLogger::DobbyLogger(const std::shared_ptr<const IDobbySettings> &settings)
+{
+}
+
+DobbyLogger::~DobbyLogger()
+{
+}
+
+void DobbyLogger::setImpl(DobbyLoggerImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyLogger* DobbyLogger::getInstance()
+{
+    static DobbyLogger* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyLogger();
+    }
+    return instance;
+}
+
+bool DobbyLogger::StartContainerLogging(std::string containerId,pid_t runtimePid,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->StartContainerLogging(containerId,runtimePid,containerPid,loggingPlugin);
+}
+
+bool DobbyLogger::DumpBuffer(int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->DumpBuffer(bufferMemFd,containerPid,loggingPlugin);
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyLoggerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyLoggerMock.h
@@ -21,7 +21,7 @@
 #include <gmock/gmock.h>
 #include "DobbyLogger.h"
 
-class DobbyLoggerMock : public DobbyLogger {
+class DobbyLoggerMock : public DobbyLoggerImpl {
 public:
 
     virtual ~DobbyLoggerMock() = default;
@@ -29,6 +29,8 @@ public:
     MOCK_METHOD(bool, StartContainerLogging, (std::string containerId,
                                pid_t runtimePid,
                                pid_t containerPid,
-                               std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin), ());
+                               std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin), (override));
+
+    MOCK_METHOD(bool, DumpBuffer, (int bufferMemFd,pid_t containerPid,std::shared_ptr<IDobbyRdkLoggingPlugin> loggingPlugin), (override));
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyManagerMock.cpp
@@ -1,0 +1,150 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyEnv.h"
+#include "DobbyUtils.h"
+#include "DobbyIPCUtils.h"
+#include "DobbyManagerMock.h"
+
+DobbyManager::DobbyManager()
+{
+}
+
+DobbyManager::DobbyManager(std::shared_ptr<DobbyEnv>&, std::shared_ptr<DobbyUtils>&, std::shared_ptr<DobbyIPCUtils>&, const std::shared_ptr<const IDobbySettings>&, std::function<void(int, const ContainerId&)>&, std::function<void(int, const ContainerId&, int)>&)
+{
+}
+
+DobbyManager::~DobbyManager()
+{
+}
+
+void DobbyManager::setImpl(DobbyManagerImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyManager* DobbyManager::getInstance()
+{
+    static DobbyManager* instance = nullptr;
+    if(nullptr == instance)
+    {
+        instance = new DobbyManager();
+    }
+    return instance;
+}
+
+#if defined(LEGACY_COMPONENTS)
+
+int32_t DobbyManager::startContainerFromSpec(const ContainerId& id,
+                                      const std::string& jsonSpec,
+                                      const std::list<int>& files,
+                                      const std::string& command,
+                                      const std::string& displaySocket,
+                                      const std::vector<std::string>& envVars)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->startContainerFromSpec(id, jsonSpec, files, command, displaySocket, envVars);
+}
+
+std::string DobbyManager::specOfContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->specOfContainer(cd);
+}
+
+bool DobbyManager::createBundle(const ContainerId& id, const std::string& jsonSpec)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->createBundle(id, jsonSpec);
+}
+#endif //defined(LEGACY_COMPONENTS)
+
+int32_t DobbyManager::startContainerFromBundle(const ContainerId& id,
+                                        const std::string& bundlePath,
+                                        const std::list<int>& files,
+                                        const std::string& command,
+                                        const std::string& displaySocket,
+                                        const std::vector<std::string>& envVars)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->startContainerFromBundle(id, bundlePath, files, command, displaySocket, envVars);
+}
+
+bool DobbyManager::stopContainer(int32_t cd, bool withPrejudice)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->stopContainer(cd, withPrejudice);
+}
+
+bool DobbyManager::pauseContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->pauseContainer(cd);
+}
+
+bool DobbyManager::resumeContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->resumeContainer(cd);
+}
+
+bool DobbyManager::execInContainer(int32_t cd,
+                            const std::string& options,
+                            const std::string& command)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->execInContainer(cd, options, command);
+}
+
+std::list<std::pair<int32_t, ContainerId>> DobbyManager::listContainers()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->listContainers();
+}
+
+int32_t DobbyManager::stateOfContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->stateOfContainer(cd);
+}
+
+std::string DobbyManager::statsOfContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->statsOfContainer(cd);
+}
+
+std::string DobbyManager::ociConfigOfContainer(int32_t cd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->ociConfigOfContainer(cd);
+}
+
+

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginManager.h
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginManager.h
@@ -30,8 +30,10 @@ class DobbyRdkPluginManagerImpl {
 
 public:
 
+    virtual bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ) const = 0;
+    virtual bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const = 0;
+    virtual void setExitStatus(int status) = 0;
     virtual const std::vector<std::string> listLoadedPlugins() const = 0;
-
     virtual std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger() const = 0;
 
 };
@@ -43,43 +45,17 @@ protected:
 
 public:
 
-    DobbyRdkPluginManager(){}
-
-    DobbyRdkPluginManager(std::shared_ptr<rt_dobby_schema> containerConfig,const std::string &rootfsPath,const std::string &pluginPath,const std::shared_ptr<DobbyRdkPluginUtils> &utils){}
-
+    DobbyRdkPluginManager();
+    DobbyRdkPluginManager(std::shared_ptr<rt_dobby_schema> containerConfig,const std::string &rootfsPath,const std::string &pluginPath,const std::shared_ptr<DobbyRdkPluginUtils> &utils);
     ~DobbyRdkPluginManager();
 
-    virtual bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ) const ;
-
-    virtual bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint) const ;
-
-    void setExitStatus(int status) const;
-
-    static void setImpl(DobbyRdkPluginManagerImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyRdkPluginManager* getInstance()
-    {
-        static DobbyRdkPluginManager* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbyRdkPluginManager();
-        }
-        return instance;
-    }
-
-    static const std::vector<std::string> listLoadedPlugins()
-    {
-        return impl->listLoadedPlugins();
-    }
-
-    static std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger()
-    {
-        return impl->getContainerLogger();
-    }
-
+    static void setImpl(DobbyRdkPluginManagerImpl* newImpl);
+    static DobbyRdkPluginManager* getInstance();
+    static bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs );
+    static bool runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint);
+    static void setExitStatus(int status);
+    static const std::vector<std::string> listLoadedPlugins();
+    static std::shared_ptr<IDobbyRdkLoggingPlugin> getContainerLogger();
 
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.cpp
@@ -1,0 +1,83 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyRdkPluginManagerMock.h"
+
+DobbyRdkPluginManager::DobbyRdkPluginManager()
+{
+}
+
+DobbyRdkPluginManager::DobbyRdkPluginManager(std::shared_ptr<rt_dobby_schema> containerConfig,const std::string &rootfsPath,const std::string &pluginPath,const std::shared_ptr<DobbyRdkPluginUtils> &utils)
+{
+}
+
+DobbyRdkPluginManager::~DobbyRdkPluginManager()
+{
+}
+
+void DobbyRdkPluginManager::setImpl(DobbyRdkPluginManagerImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyRdkPluginManager* DobbyRdkPluginManager::getInstance()
+{
+    static DobbyRdkPluginManager* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyRdkPluginManager();
+    }
+    return instance;
+}
+
+bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs )
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->runPlugins(hookPoint,timeoutMs);
+}
+
+bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoint)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->runPlugins(hookPoint);
+}
+
+void DobbyRdkPluginManager::setExitStatus(int status)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setExitStatus(status);
+}
+
+const std::vector<std::string> DobbyRdkPluginManager::listLoadedPlugins()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->listLoadedPlugins();
+}
+
+std::shared_ptr<IDobbyRdkLoggingPlugin> DobbyRdkPluginManager::getContainerLogger()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getContainerLogger();
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginManagerMock.h
@@ -27,9 +27,10 @@ class DobbyRdkPluginManagerMock : public DobbyRdkPluginManagerImpl {
 public:
 
     virtual ~DobbyRdkPluginManagerMock() = default;
-
+    MOCK_METHOD(void, setExitStatus, (int status), (override));
     MOCK_METHOD(const std::vector<std::string>, listLoadedPlugins, (), (const,override));
     MOCK_METHOD(std::shared_ptr<IDobbyRdkLoggingPlugin>, getContainerLogger, (), (const,override));
-
+    MOCK_METHOD(bool, runPlugins,(const IDobbyRdkPlugin::HintFlags &hookPoint,const uint timeoutMs ),( const,override));
+    MOCK_METHOD(bool, runPlugins,(const IDobbyRdkPlugin::HintFlags &hookPoint),( const,override));
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginUtils.h
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginUtils.h
@@ -85,7 +85,7 @@ protected:
 
 public:
 
-    DobbyRdkPluginUtils(){}
+    DobbyRdkPluginUtils();
 
     DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
                         const std::string &containerId);
@@ -100,92 +100,24 @@ public:
                         const std::shared_ptr<IDobbyStartState> &startState,
                         const std::string &containerId);
 
-    ~DobbyRdkPluginUtils(){}
+    ~DobbyRdkPluginUtils();
 
-    static void setImpl(DobbyRdkPluginUtilsImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyRdkPluginUtils* getInstance()
-    {
-        static DobbyRdkPluginUtils* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbyRdkPluginUtils();
-        }
-        return instance;
-    }
-
-    static bool callInNamespaceImpl(pid_t pid, int nsType,const std::function<bool()>& func)
-    {
-        return impl->callInNamespaceImpl(pid,nsType,func);
-    }
-
-    static void nsThread(int newNsFd, int nsType, bool* success,std::function<bool()>& func)
-    {
-        return impl->nsThread(newNsFd,nsType,success,func);
-    }
-
-    static pid_t getContainerPid()
-    {
-        return impl->getContainerPid();
-    }
-
-    static std::string getContainerId()
-    {
-        return impl->getContainerId();
-    }
-
-    static bool getContainerNetworkInfo(ContainerNetworkInfo &networkInfo)
-    {
-        return impl->getContainerNetworkInfo(networkInfo);
-    }
-
-    static bool getTakenVeths(std::vector<std::string> &takenVeths)
-    {
-        return impl->getTakenVeths(takenVeths);
-    }
-
-    static bool writeTextFile(const std::string &path,const std::string &str,int flags,mode_t mode)
-    {
-        return impl->writeTextFile(path,str,flags,mode);
-    }
-
-    static std::string readTextFile(const std::string &path)
-    {
-        return impl->readTextFile(path);
-    }
-
-    static bool addMount(const std::string &source,const std::string &target,const std::string &fsType,const std::list<std::string> &mountOptions)
-    {
-        return impl->addMount(source,target,fsType,mountOptions);
-    }
-
-    static bool mkdirRecursive(const std::string& path, mode_t mode)
-    {
-        return impl->mkdirRecursive(path,mode);
-    }
-
-    static bool addEnvironmentVar(const std::string& envVar)
-    {
-        return impl->addEnvironmentVar(envVar);
-    }
-
-    static int addFileDescriptor(const std::string& pluginName, int fd)
-    {
-        return impl->addFileDescriptor(pluginName,fd);
-    }
-
-    static std::list<int> files()
-    {
-        return impl->files();
-    }
-
-    static std::list<int> files(const std::string& pluginName)
-    {
-        return impl->files(pluginName);
-    }
+    static void setImpl(DobbyRdkPluginUtilsImpl* newImpl);
+    static DobbyRdkPluginUtils* getInstance();
+    static bool callInNamespaceImpl(pid_t pid, int nsType,const std::function<bool()>& func);
+    static void nsThread(int newNsFd, int nsType, bool* success,std::function<bool()>& func);
+    static pid_t getContainerPid();
+    static std::string getContainerId();
+    static bool getContainerNetworkInfo(ContainerNetworkInfo &networkInfo);
+    static bool getTakenVeths(std::vector<std::string> &takenVeths);
+    static bool writeTextFile(const std::string &path,const std::string &str,int flags,mode_t mode);
+    static std::string readTextFile(const std::string &path);
+    static bool addMount(const std::string &source,const std::string &target,const std::string &fsType,const std::list<std::string> &mountOptions);
+    static bool mkdirRecursive(const std::string& path, mode_t mode);
+    static bool addEnvironmentVar(const std::string& envVar);
+    static int addFileDescriptor(const std::string& pluginName, int fd);
+    static std::list<int> files();
+    static std::list<int> files(const std::string& pluginName);
 };
 
 

--- a/unit_tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRdkPluginUtilsMock.cpp
@@ -1,0 +1,166 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyRdkPluginUtilsMock.h"
+
+DobbyRdkPluginUtils::DobbyRdkPluginUtils()
+{
+}
+
+DobbyRdkPluginUtils::DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
+                    const std::string &containerId)
+{
+}
+
+DobbyRdkPluginUtils::DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
+                    const std::shared_ptr<IDobbyStartState> &startState,
+                    const std::string &containerId)
+{
+}
+
+DobbyRdkPluginUtils::DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
+                    const std::shared_ptr<const rt_state_schema> &state,
+                    const std::string &containerId)
+{
+}
+
+DobbyRdkPluginUtils::DobbyRdkPluginUtils(const std::shared_ptr<rt_dobby_schema> &cfg,
+                    const std::shared_ptr<const rt_state_schema> &state,
+                    const std::shared_ptr<IDobbyStartState> &startState,
+                    const std::string &containerId)
+{
+}
+
+DobbyRdkPluginUtils::~DobbyRdkPluginUtils()
+{
+}
+
+void DobbyRdkPluginUtils::setImpl(DobbyRdkPluginUtilsImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyRdkPluginUtils* DobbyRdkPluginUtils::getInstance()
+{
+    static DobbyRdkPluginUtils* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyRdkPluginUtils();
+    }
+    return instance;
+}
+
+bool DobbyRdkPluginUtils::callInNamespaceImpl(pid_t pid, int nsType,const std::function<bool()>& func)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->callInNamespaceImpl(pid,nsType,func);
+}
+
+void DobbyRdkPluginUtils::nsThread(int newNsFd, int nsType, bool* success,std::function<bool()>& func)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->nsThread(newNsFd,nsType,success,func);
+}
+
+pid_t DobbyRdkPluginUtils::getContainerPid()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getContainerPid();
+}
+
+std::string DobbyRdkPluginUtils::getContainerId()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getContainerId();
+}
+
+bool DobbyRdkPluginUtils::getContainerNetworkInfo(ContainerNetworkInfo &networkInfo)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getContainerNetworkInfo(networkInfo);
+}
+
+bool DobbyRdkPluginUtils::getTakenVeths(std::vector<std::string> &takenVeths)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getTakenVeths(takenVeths);
+}
+
+bool DobbyRdkPluginUtils::writeTextFile(const std::string &path,const std::string &str,int flags,mode_t mode)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->writeTextFile(path,str,flags,mode);
+}
+
+std::string DobbyRdkPluginUtils::readTextFile(const std::string &path)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->readTextFile(path);
+}
+
+bool DobbyRdkPluginUtils::addMount(const std::string &source,const std::string &target,const std::string &fsType,const std::list<std::string> &mountOptions)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addMount(source,target,fsType,mountOptions);
+}
+
+bool DobbyRdkPluginUtils::mkdirRecursive(const std::string& path, mode_t mode)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->mkdirRecursive(path,mode);
+}
+
+bool DobbyRdkPluginUtils::addEnvironmentVar(const std::string& envVar)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addEnvironmentVar(envVar);
+}
+
+int DobbyRdkPluginUtils::addFileDescriptor(const std::string& pluginName, int fd)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->addFileDescriptor(pluginName,fd);
+}
+
+std::list<int> DobbyRdkPluginUtils::files()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->files();
+}
+
+std::list<int> DobbyRdkPluginUtils::files(const std::string& pluginName)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->files(pluginName);
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyRootfs.h
+++ b/unit_tests/L1_testing/mocks/DobbyRootfs.h
@@ -49,43 +49,19 @@ protected:
 
 public:
 
-    DobbyRootfs(){}
+    DobbyRootfs();
 #if defined(LEGACY_COMPONENTS)
-    DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const DobbyBundle>& bundle,const std::shared_ptr<const DobbySpecConfig>& config){}
+    DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const DobbyBundle>& bundle,const std::shared_ptr<const DobbySpecConfig>& config);
 #endif // LEGACY_COMPONENTS
 
-    DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const DobbyBundle>& bundle,const std::shared_ptr<const DobbyBundleConfig>& config){}
-    ~DobbyRootfs(){}
+    DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const DobbyBundle>& bundle,const std::shared_ptr<const DobbyBundleConfig>& config);
+    ~DobbyRootfs();
 
-    static void setImpl(DobbyRootfsImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyRootfs* getInstance()
-    {
-        static DobbyRootfs* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbyRootfs();
-        }
-        return instance;
-    }
-
-    static void setPersistence(bool persist)
-    {
-        return impl->setPersistence(persist);
-    }
-
-    static const std::string& path()
-    {
-        return impl->path();
-    }
-
-    static bool isValid()
-    {
-        return impl->isValid();
-    }
+    static void setImpl(DobbyRootfsImpl* newImpl);
+    static DobbyRootfs* getInstance();
+    static void setPersistence(bool persist);
+    static const std::string& path();
+    static bool isValid();
 };
 
 #endif // !defined(DOBBYROOTFS_H)

--- a/unit_tests/L1_testing/mocks/DobbyRootfsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRootfsMock.cpp
@@ -1,0 +1,75 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyRootfsMock.h"
+
+DobbyRootfs::DobbyRootfs()
+{
+}
+
+#if defined(LEGACY_COMPONENTS)
+DobbyRootfs::DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const DobbyBundle>& bundle,const std::shared_ptr<const DobbySpecConfig>& config)
+{
+}
+#endif // LEGACY_COMPONENTS
+
+DobbyRootfs::DobbyRootfs(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const DobbyBundle>& bundle,const std::shared_ptr<const DobbyBundleConfig>& config)
+{
+}
+
+DobbyRootfs::~DobbyRootfs()
+{
+}
+
+void DobbyRootfs::setImpl(DobbyRootfsImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyRootfs* DobbyRootfs::getInstance()
+{
+    static DobbyRootfs* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyRootfs();
+    }
+    return instance;
+}
+
+void DobbyRootfs::setPersistence(bool persist)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setPersistence(persist);
+}
+
+const std::string& DobbyRootfs::path()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->path();
+}
+
+bool DobbyRootfs::isValid()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->isValid();
+}
+
+

--- a/unit_tests/L1_testing/mocks/DobbyRunC.h
+++ b/unit_tests/L1_testing/mocks/DobbyRunC.h
@@ -1,0 +1,115 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyRunc.h
+ *
+ */
+#ifndef DOBBYRUNC_H
+#define DOBBYRUNC_H
+
+#include "IDobbyUtils.h"
+#include "DobbyLogger.h"
+#include "ContainerId.h"
+
+#include <json/json.h>
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+class DobbyBundle;
+class IDobbyStream;
+
+// -----------------------------------------------------------------------------
+
+class DobbyRunCImpl;
+
+class DobbyRunC
+{
+protected:
+    static DobbyRunCImpl* impl;
+public:
+    DobbyRunC(const std::shared_ptr<IDobbyUtils> &utils,
+                       const std::shared_ptr<const IDobbySettings> &settings);
+    ~DobbyRunC();
+
+public:
+enum class ContainerStatus
+{
+    Unknown,
+    Created,
+    Running,
+    Pausing,
+    Paused,
+    Stopped
+};
+
+struct ContainerListItem
+{
+    ContainerId id;
+    pid_t pid;
+    std::string bundlePath;
+    ContainerStatus status;
+};
+public:
+    DobbyRunC();
+    static void setImpl(DobbyRunCImpl* newImpl);
+    static DobbyRunC* getInstance();
+
+    std::pair<pid_t, pid_t> create(const ContainerId &id,
+                                   const std::shared_ptr<const DobbyBundle> &bundle,
+                                   const std::shared_ptr<const IDobbyStream> &console,
+                                   const std::list<int> &files = std::list<int>(),
+                                   const std::string& customConfigPath = "") const;
+    bool destroy(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console, bool force = false) const;
+    bool start(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console) const;
+    bool killCont(const ContainerId &id, int signal, bool all = false) const;
+    bool pause(const ContainerId &id) const;
+    bool resume(const ContainerId &id) const;
+    std::pair<pid_t, pid_t> exec(const ContainerId &id,
+                                 const std::string &options,
+                                 const std::string &command) const;
+    ContainerStatus state(const ContainerId &id) const;
+    std::list<ContainerListItem> list() const;
+    const std::string getWorkingDir() const;
+};
+
+class DobbyRunCImpl
+{
+public:
+    virtual std::pair<pid_t, pid_t> create(const ContainerId &id,
+                                   const std::shared_ptr<const DobbyBundle> &bundle,
+                                   const std::shared_ptr<const IDobbyStream> &console,
+                                   const std::list<int> &files = std::list<int>(),
+                                   const std::string& customConfigPath = "") const = 0;
+    virtual bool destroy(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console, bool force = false) const = 0;
+    virtual bool start(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console) const = 0;
+    virtual bool killCont(const ContainerId &id, int signal, bool all = false) const = 0;
+    virtual bool pause(const ContainerId &id) const = 0;
+    virtual bool resume(const ContainerId &id) const = 0;
+    virtual std::pair<pid_t, pid_t> exec(const ContainerId &id,
+                                 const std::string &options,
+                                 const std::string &command) const = 0;
+
+    virtual DobbyRunC::ContainerStatus state(const ContainerId &id) const = 0;
+    virtual std::list<DobbyRunC::ContainerListItem> list() const = 0;
+    virtual const std::string getWorkingDir() const = 0;
+};
+
+#endif // !defined(DOBBYRUNC_H)

--- a/unit_tests/L1_testing/mocks/DobbyRunCMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyRunCMock.cpp
@@ -1,0 +1,125 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyRunCMock.h"
+
+std::pair<pid_t, pid_t>DobbyRunC::create(const ContainerId &id,
+                                   const std::shared_ptr<const DobbyBundle> &bundle,
+                                   const std::shared_ptr<const IDobbyStream> &console,
+                                   const std::list<int> &files, /*= std::list<int>()*/
+                                          const std::string& customConfigPath /*= ""*/) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->create( id, bundle, console, files, customConfigPath);
+}
+
+bool DobbyRunC::destroy(const ContainerId& id, const std::shared_ptr<const IDobbyStream>& console, bool force /*= false*/) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->destroy( id, console, force);
+}
+
+bool DobbyRunC::start(const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->start( id, console);
+}
+
+bool DobbyRunC::killCont(const ContainerId& id, int signal, bool all) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->killCont( id, signal, all);
+}
+
+bool DobbyRunC::pause(const ContainerId &id) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->pause( id );
+}
+
+bool DobbyRunC::resume(const ContainerId &id) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->resume( id );
+}
+
+std::pair<pid_t, pid_t> DobbyRunC::exec(const ContainerId &id,
+                                 const std::string &options,
+                                 const std::string &command) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->exec( id, options, command);
+}
+
+DobbyRunC::ContainerStatus DobbyRunC::state(const ContainerId& id) const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->state(id);
+}
+
+std::list<DobbyRunC::ContainerListItem> DobbyRunC::list() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->list();
+}
+
+const std::string DobbyRunC::getWorkingDir() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getWorkingDir();
+}
+
+DobbyRunC::DobbyRunC(const std::shared_ptr<IDobbyUtils>& utils,
+                     const std::shared_ptr<const IDobbySettings> &settings)
+{
+}
+
+DobbyRunC::DobbyRunC()
+{
+}
+
+DobbyRunC::~DobbyRunC()
+{
+}
+
+DobbyRunC* DobbyRunC::getInstance()
+{
+    static DobbyRunC* instance = nullptr;
+    if (nullptr == instance)
+    {
+        instance = new DobbyRunC();
+    }
+    return instance;
+}
+
+void DobbyRunC::setImpl(DobbyRunCImpl* newImpl)
+{
+    impl = newImpl;
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyRunCMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyRunCMock.h
@@ -21,13 +21,25 @@
 #include <gmock/gmock.h>
 #include "DobbyRunC.h"
 
-class DobbyRunCMock : public DobbyRunC {
+class DobbyRunCMock : public DobbyRunCImpl {
+
 public:
 
     virtual ~DobbyRunCMock() = default;
-    MOCK_METHOD(bool, killCont, (const ContainerId &id, int signal, bool all), (const));
-    MOCK_METHOD(bool, resume, (const ContainerId& id), (const));
-    MOCK_METHOD(bool, pause, (const ContainerId& id), (const));
-    MOCK_METHOD((std::pair<pid_t, pid_t>), exec, (const ContainerId& id, const std::string& options, const std::string& command), (const));
+
+    MOCK_METHOD((std::pair<pid_t, pid_t>), create, ((const ContainerId &id),
+                                   (const std::shared_ptr<const DobbyBundle> &bundle),
+                                   (const std::shared_ptr<const IDobbyStream> &console),
+                                   (const std::list<int> &files),
+                                   (const std::string& customConfigPath)), (const,override));
+    MOCK_METHOD(bool, destroy, (const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console, bool force), (const,override));
+    MOCK_METHOD(bool, start, (const ContainerId &id, const std::shared_ptr<const IDobbyStream> &console), (const,override));
+    MOCK_METHOD(bool, killCont, (const ContainerId &id, int signal, bool all), (const,override));
+    MOCK_METHOD(bool, resume, (const ContainerId& id), (const,override));
+    MOCK_METHOD(bool, pause, (const ContainerId& id), (const,override));
+    MOCK_METHOD((std::pair<pid_t, pid_t>), exec, ((const ContainerId& id), (const std::string& options), (const std::string& command)), (const,override));
+    MOCK_METHOD(DobbyRunC::ContainerStatus, state, (const ContainerId& id), (const,override));
+    MOCK_METHOD(std::list<DobbyRunC::ContainerListItem>, list, (), (const,override));
+    MOCK_METHOD(const std::string, getWorkingDir, (), (const,override));
 };
 

--- a/unit_tests/L1_testing/mocks/DobbySpecConfig.h
+++ b/unit_tests/L1_testing/mocks/DobbySpecConfig.h
@@ -54,60 +54,23 @@ protected:
 
 public:
 
-    DobbySpecConfig(){}
+    DobbySpecConfig();
+    DobbySpecConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const ContainerId& id,const std::shared_ptr<const DobbyBundle>& bundle,const std::string& specJson);
+    DobbySpecConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const std::shared_ptr<const DobbyBundle>& bundle,const std::string& specJson);
+    ~DobbySpecConfig();
 
-    DobbySpecConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const ContainerId& id,const std::shared_ptr<const DobbyBundle>& bundle,const std::string& specJson){}
-    DobbySpecConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const std::shared_ptr<const DobbyBundle>& bundle,const std::string& specJson){}
-
-    ~DobbySpecConfig(){}
-
-    static void setImpl(DobbySpecConfigImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbySpecConfig* getInstance()
-    {
-        static DobbySpecConfig* instance = nullptr;
-        if (nullptr == instance)
-        {
-           instance = new DobbySpecConfig();
-        }
-        return instance;
-    }
-
-    static bool isValid()
-    {
-        return impl->isValid();
-    }
-
-    static const std::map<std::string, Json::Value>& rdkPlugins()
-    {
-        return impl->rdkPlugins();
-    }
-
+    static void setImpl(DobbySpecConfigImpl* newImpl);
+    static DobbySpecConfig* getInstance();
+    static bool isValid();
+    static const std::map<std::string, Json::Value>& rdkPlugins();
 #if defined(LEGACY_COMPONENTS)
 
-    static const std::string spec()
-    {
-        return impl->spec();
-    }
+    static const std::string spec();
 #endif //defined(LEGACY_COMPONENTS)
 
-    static std::shared_ptr<rt_dobby_schema> config()
-    {
-        return impl->config();
-    }
-
-    static bool restartOnCrash()
-    {
-        return impl->restartOnCrash();
-    }
-
-    static bool writeConfigJson(const std::string& filePath)
-    {
-        return impl->writeConfigJson(filePath);
-    }
+    static std::shared_ptr<rt_dobby_schema> config();
+    static bool restartOnCrash();
+    static bool writeConfigJson(const std::string& filePath);
 };
 
 #endif // !defined(DOBBYSPECCONFIG_H)

--- a/unit_tests/L1_testing/mocks/DobbySpecConfigMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbySpecConfigMock.cpp
@@ -1,0 +1,96 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbySpecConfigMock.h"
+
+DobbySpecConfig::DobbySpecConfig()
+{
+}
+
+DobbySpecConfig::DobbySpecConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const ContainerId& id,const std::shared_ptr<const DobbyBundle>& bundle,const std::string& specJson)
+{
+}
+
+DobbySpecConfig::DobbySpecConfig(const std::shared_ptr<IDobbyUtils>& utils,const std::shared_ptr<const IDobbySettings>& settings,const std::shared_ptr<const DobbyBundle>& bundle,const std::string& specJson)
+{
+}
+
+DobbySpecConfig::~DobbySpecConfig()
+{
+}
+
+void DobbySpecConfig::setImpl(DobbySpecConfigImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbySpecConfig* DobbySpecConfig::getInstance()
+{
+    static DobbySpecConfig* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbySpecConfig();
+    }
+    return instance;
+}
+
+bool DobbySpecConfig::isValid()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->isValid();
+}
+
+const std::map<std::string, Json::Value>& DobbySpecConfig::rdkPlugins()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->rdkPlugins();
+}
+
+#if defined(LEGACY_COMPONENTS)
+
+const std::string DobbySpecConfig::spec()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->spec();
+}
+#endif //defined(LEGACY_COMPONENTS)
+
+std::shared_ptr<rt_dobby_schema> DobbySpecConfig::config()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->config();
+}
+
+bool DobbySpecConfig::restartOnCrash()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->restartOnCrash();
+}
+
+bool DobbySpecConfig::writeConfigJson(const std::string& filePath)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->writeConfigJson(filePath);
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyStartState.h
+++ b/unit_tests/L1_testing/mocks/DobbyStartState.h
@@ -1,0 +1,59 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef DOBBYSTARTSTATE_H
+#define DOBBYSTARTSTATE_H
+
+#include <set>
+#include <bitset>
+#include <memory>
+
+#include <ContainerId.h>
+#include "IDobbyStartState.h"
+
+class DobbyConfig;
+
+class DobbyStartStateImpl {
+public:
+
+    virtual ~DobbyStartStateImpl() = default;
+    virtual std::list<int> files() const =0;
+    virtual bool isValid() const = 0;
+};
+
+class DobbyStartState : public IDobbyStartState{
+
+protected:
+    static DobbyStartStateImpl* impl;
+
+public:
+
+    DobbyStartState();
+    DobbyStartState(const std::shared_ptr<DobbyConfig>& config,const std::list<int>& files);
+    ~DobbyStartState();
+    static void setImpl(DobbyStartStateImpl* newImpl);
+    static DobbyStartState* getInstance();
+    static bool isValid();
+    std::list<int> files() const;
+
+};
+
+
+#endif // !defined(DOBBYSTARTSTATE_H)
+

--- a/unit_tests/L1_testing/mocks/DobbyStartStateMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyStartStateMock.cpp
@@ -1,0 +1,70 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "DobbyStartStateMock.h"
+
+IDobbyStartState::IDobbyStartState()
+{
+}
+
+IDobbyStartState::~IDobbyStartState()
+{
+}
+
+DobbyStartState::DobbyStartState()
+{
+}
+
+DobbyStartState::DobbyStartState(const std::shared_ptr<DobbyConfig>& config,const std::list<int>& files)
+{
+}
+
+DobbyStartState::~DobbyStartState()
+{
+}
+
+void DobbyStartState::setImpl(DobbyStartStateImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyStartState* DobbyStartState::getInstance()
+{
+    static DobbyStartState* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyStartState();
+    }
+    return instance;
+}
+
+std::list<int> DobbyStartState::files() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->files();
+}
+
+bool DobbyStartState::isValid()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->isValid();
+}
+

--- a/unit_tests/L1_testing/mocks/DobbyStartStateMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyStartStateMock.h
@@ -20,15 +20,13 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include <IDobbyStartState.h>
+#include "DobbyStartState.h"
 
-class DobbyStartStateMock : public IDobbyStartState{
+
+class DobbyStartStateMock : public DobbyStartStateImpl{
 public:
 
     MOCK_METHOD(std::list<int>, files, (), (const,override));
-    MOCK_METHOD(int, addFileDescriptor, (const std::string& pluginName, int fd), (override));
-    MOCK_METHOD(bool, addEnvironmentVariable, (const std::string& envVar), (override));
-    MOCK_METHOD(bool, addMount, (const std::string& source,const std::string& target,const std::string& fsType,unsigned long mountFlags,const std::list<std::string>& mountOptions), (override));
-    MOCK_METHOD(std::list<int>, files, (const std::string& pluginName), (const,override));
+    MOCK_METHOD(bool, isValid, (), (const,override));
 
 };

--- a/unit_tests/L1_testing/mocks/DobbyStats.h
+++ b/unit_tests/L1_testing/mocks/DobbyStats.h
@@ -1,0 +1,67 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyRunc.h
+ *
+ */
+
+#ifndef DOBBYSTATS_H
+#define DOBBYSTATS_H
+
+#include <ContainerId.h>
+#include <IDobbyEnv.h>
+#include "IDobbyUtils.h"
+
+#include <memory>
+#include <string>
+
+#if defined(RDK)
+#include <json/json.h>
+#else
+#include <jsoncpp/json.h>
+#endif
+
+class IDobbyEnv;
+
+class DobbyStatsImpl {
+public:
+
+    virtual ~DobbyStatsImpl() = default;
+
+    virtual const Json::Value &stats() const = 0;
+
+};
+
+class DobbyStats {
+protected:
+    static DobbyStatsImpl* impl;
+
+public:
+    DobbyStats();
+    DobbyStats(const ContainerId &id,const std::shared_ptr<IDobbyEnv> &env,const std::shared_ptr<IDobbyUtils> &utils);
+    ~DobbyStats();
+
+    static void setImpl(DobbyStatsImpl* newImpl);
+    static DobbyStats* getInstance();
+    static const Json::Value & stats();
+};
+
+#endif // !defined(DOBBYSTATS_H)
+
+

--- a/unit_tests/L1_testing/mocks/DobbyStatsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyStatsMock.cpp
@@ -1,0 +1,53 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyStatsMock.h"
+
+DobbyStats::DobbyStats()
+{
+}
+
+DobbyStats::DobbyStats(const ContainerId &id,const std::shared_ptr<IDobbyEnv> &env,const std::shared_ptr<IDobbyUtils> &utils)
+{
+}
+
+DobbyStats::~DobbyStats()
+{
+}
+
+void DobbyStats::setImpl(DobbyStatsImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyStats* DobbyStats::getInstance()
+{
+    static DobbyStats* instance = nullptr;
+    if (nullptr == instance)
+    {
+       instance = new DobbyStats();
+    }
+    return instance;
+}
+
+const Json::Value & DobbyStats::stats()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->stats();
+}

--- a/unit_tests/L1_testing/mocks/DobbyStatsMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyStatsMock.h
@@ -21,7 +21,7 @@
 #include <gmock/gmock.h>
 #include "DobbyStats.h"
 
-class DobbyStatsMock : public DobbyStats {
+class DobbyStatsMock : public DobbyStatsImpl {
 public:
 
     virtual ~DobbyStatsMock() = default;

--- a/unit_tests/L1_testing/mocks/DobbyStream.h
+++ b/unit_tests/L1_testing/mocks/DobbyStream.h
@@ -1,0 +1,97 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+ * File:   DobbyStream.h
+ *
+ */
+#ifndef DOBBYSTREAM_H
+#define DOBBYSTREAM_H
+
+#include <sys/types.h>
+
+#include <string>
+#include <thread>
+#include <vector>
+
+// -----------------------------------------------------------------------------
+/**
+ *  @interface IDobbyStream
+ *  @brief Interface for all character streams used in the daemon
+ *
+ *
+ *
+ */
+class IDobbyStream
+{
+public:
+    virtual ~IDobbyStream() = default;
+
+public:
+    virtual int dupWriteFD(int newFd = -1, bool closeExec = true) const = 0;
+};
+
+
+// -----------------------------------------------------------------------------
+/**
+ *  @class DobbyDevNullStream
+ *  @brief Stream that just redirects all the input to /dev/null
+ *
+ *  This simply returns the fd for /dev/null in the dupWriteFD call.
+ *
+ */
+class DobbyDevNullStream : public IDobbyStream
+{
+public:
+    ~DobbyDevNullStream() final = default;
+
+public:
+    int dupWriteFD(int newFd, bool closeExec) const
+    {
+        return -1;
+    }
+};
+
+
+class DobbyBufferStreamImpl
+{
+public:
+    virtual ~DobbyBufferStreamImpl() = default;
+    virtual std::vector<char> getBuffer() const = 0;
+    virtual int getMemFd() const = 0;
+};
+// -----------------------------------------------------------------------------
+class DobbyBufferStream : public IDobbyStream
+{
+protected:
+    static DobbyBufferStreamImpl *impl;
+public:
+    DobbyBufferStream(ssize_t limit = -1);
+    ~DobbyBufferStream();
+
+public:
+    int dupWriteFD(int newFd, bool closeExec) const;
+public:
+    static void setImpl(DobbyBufferStreamImpl* newImpl);
+    static DobbyBufferStream* getInstance();
+    static std::vector<char> getBuffer();
+    static int getMemFd();
+
+};
+
+#endif // !defined(DOBBYSTREAM_H)

--- a/unit_tests/L1_testing/mocks/DobbyStreamMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyStreamMock.cpp
@@ -1,0 +1,61 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyStreamMock.h"
+
+DobbyBufferStream::DobbyBufferStream(ssize_t limit)
+{
+}
+
+DobbyBufferStream::~DobbyBufferStream()
+{
+}
+
+int DobbyBufferStream::dupWriteFD(int newFd, bool closeExec) const
+{
+    return -1;
+}
+
+void DobbyBufferStream::setImpl(DobbyBufferStreamImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyBufferStream* DobbyBufferStream::getInstance()
+{
+    static DobbyBufferStream* instance = nullptr;
+    if(nullptr == instance)
+    {
+        instance = new DobbyBufferStream();
+    }
+    return instance;
+}
+
+std::vector<char> DobbyBufferStream::getBuffer()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getBuffer();
+}
+
+int DobbyBufferStream::getMemFd()
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->getMemFd();
+}

--- a/unit_tests/L1_testing/mocks/DobbyStreamMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyStreamMock.h
@@ -1,0 +1,31 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "DobbyStream.h"
+
+class DobbyStreamMock : public DobbyBufferStreamImpl {
+
+public:
+
+    virtual ~DobbyStreamMock() = default;
+    MOCK_METHOD((std::vector<char>), getBuffer, (), (const,override));
+    MOCK_METHOD(int, getMemFd, (), (const,override));
+};

--- a/unit_tests/L1_testing/mocks/DobbyTemplate.h
+++ b/unit_tests/L1_testing/mocks/DobbyTemplate.h
@@ -34,7 +34,7 @@ class DobbyTemplateImpl {
 public:
 
     virtual ~DobbyTemplateImpl() = default;
-    virtual void setSettings(const std::shared_ptr<const IDobbySettings>& settings) = 0;
+    virtual void setSettings(const std::shared_ptr<const IDobbySettings>& settings) const = 0;
     virtual std::string apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint) = 0;
     virtual bool applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint) = 0;
 };
@@ -47,34 +47,12 @@ protected:
 
 public:
 
-    DobbyTemplate(){}
-
-    static void setImpl(DobbyTemplateImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyTemplate* getInstance()
-    {
-        static DobbyTemplate* instance = nullptr;
-        if(nullptr == instance)
-        {
-           instance = new DobbyTemplate();
-        }
-        return instance;
-    }
-
-    static void setSettings(const std::shared_ptr<const IDobbySettings>& settings) {
-        impl->setSettings(settings);
-    }
-
-    static std::string apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint) {
-        return impl->apply(dictionary, prettyPrint);
-    }
-
-    static bool applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint) {
-        return impl->applyAt(dirFd, fileName, dictionary, prettyPrint);
-    }
+    DobbyTemplate();
+    static void setImpl(DobbyTemplateImpl* newImpl);
+    static DobbyTemplate* getInstance();
+    static void setSettings(const std::shared_ptr<const IDobbySettings>& settings);
+    static std::string apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint);
+    static bool applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint);
 
   };
 #endif // !defined(DOBBYTEMPLATE_H)

--- a/unit_tests/L1_testing/mocks/DobbyTemplateMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyTemplateMock.cpp
@@ -1,0 +1,60 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "IDobbySettings.h"
+#include "DobbyTemplateMock.h"
+
+DobbyTemplate::DobbyTemplate()
+{
+}
+
+void DobbyTemplate::setImpl(DobbyTemplateImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyTemplate* DobbyTemplate::getInstance()
+{
+    static DobbyTemplate* instance = nullptr;
+    if(nullptr == instance)
+    {
+       instance = new DobbyTemplate();
+    }
+    return instance;
+}
+
+void DobbyTemplate::setSettings(const std::shared_ptr<const IDobbySettings>& settings)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->setSettings(settings);
+}
+
+std::string DobbyTemplate::apply(const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->apply(dictionary, prettyPrint);
+}
+
+bool DobbyTemplate::applyAt(int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->applyAt(dirFd, fileName, dictionary, prettyPrint);
+}

--- a/unit_tests/L1_testing/mocks/DobbyTemplateMock.h
+++ b/unit_tests/L1_testing/mocks/DobbyTemplateMock.h
@@ -26,7 +26,7 @@ public:
 
      virtual ~DobbyTemplateMock() = default;
 
-     MOCK_METHOD(void, setSettings, (const std::shared_ptr<const IDobbySettings>& settings), (override));
+     MOCK_METHOD(void, setSettings, (const std::shared_ptr<const IDobbySettings>& settings), (const,override));
      MOCK_METHOD(std::string, apply, (const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint), (override));
      MOCK_METHOD(bool, applyAt, (int dirFd, const std::string& fileName, const ctemplate::TemplateDictionaryInterface* dictionary, bool prettyPrint), (override));
 };

--- a/unit_tests/L1_testing/mocks/DobbyUtils.h
+++ b/unit_tests/L1_testing/mocks/DobbyUtils.h
@@ -50,36 +50,15 @@ protected:
 
 public:
 
-     DobbyUtils(){}
-    ~DobbyUtils(){}
+     DobbyUtils();
+    ~DobbyUtils();
 
-    static void setImpl(DobbyUtilsImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyUtils* getInstance()
-    {
-        static DobbyUtils* instance = nullptr;
-        if(nullptr == instance)
-        {
-            instance = new DobbyUtils();
-        }
-        return instance;
-    }
-
-
-    static bool cancelTimer(int timerId)
-    {
-        return impl->cancelTimer(timerId);
-    }
-
+    static void setImpl(DobbyUtilsImpl* newImpl);
+    static DobbyUtils* getInstance();
+    static bool cancelTimer(int timerId);
     static int startTimer(const std::chrono::microseconds& timeout,
                           bool oneShot,
-                          const std::function<bool()>& handler)
-    {
-       return impl->startTimer(timeout,oneShot,handler);
-    }
+                          const std::function<bool()>& handler);
 
 };
 

--- a/unit_tests/L1_testing/mocks/DobbyUtilsMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyUtilsMock.cpp
@@ -1,0 +1,58 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyUtilsMock.h"
+
+DobbyUtils::DobbyUtils()
+{
+}
+
+DobbyUtils::~DobbyUtils()
+{
+}
+
+void DobbyUtils::setImpl(DobbyUtilsImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyUtils* DobbyUtils::getInstance()
+{
+    static DobbyUtils* instance = nullptr;
+    if(nullptr == instance)
+    {
+        instance = new DobbyUtils();
+    }
+    return instance;
+}
+
+bool DobbyUtils::cancelTimer(int timerId)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->cancelTimer(timerId);
+}
+
+int DobbyUtils::startTimer(const std::chrono::microseconds& timeout,
+                      bool oneShot,
+                      const std::function<bool()>& handler)
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->startTimer(timeout,oneShot,handler);
+}

--- a/unit_tests/L1_testing/mocks/DobbyWorkQueue.h
+++ b/unit_tests/L1_testing/mocks/DobbyWorkQueue.h
@@ -39,37 +39,11 @@ protected:
 
 public:
 
-    static void setImpl(DobbyWorkQueueImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyWorkQueue* getInstance()
-    {
-        static DobbyWorkQueue* instance = nullptr;
-        if(nullptr == instance)
-        {
-            instance =  new DobbyWorkQueue();
-        }
-        return instance;
-    }
-
-
-    static bool runFor(const std::chrono::milliseconds &msecs)
-    {
-        return impl->runFor(msecs);
-    }
-
-    static void exit()
-    {
-        impl->exit();
-    }
-
-    static bool postWork(WorkFunc &&work)
-    {
-        return impl->postWork(work);
-    }
-
+    static void setImpl(DobbyWorkQueueImpl* newImpl);
+    static DobbyWorkQueue* getInstance();
+    static bool runFor(const std::chrono::milliseconds &msecs);
+    static void exit();
+    static bool postWork(WorkFunc &&work);
 };
 
 #endif // DOBBYWORKQUEUE_H

--- a/unit_tests/L1_testing/mocks/DobbyWorkQueueMock.cpp
+++ b/unit_tests/L1_testing/mocks/DobbyWorkQueueMock.cpp
@@ -1,0 +1,56 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "DobbyWorkQueueMock.h"
+
+void DobbyWorkQueue::setImpl(DobbyWorkQueueImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+DobbyWorkQueue* DobbyWorkQueue::getInstance()
+{
+    static DobbyWorkQueue* instance = nullptr;
+    if(nullptr == instance)
+    {
+        instance =  new DobbyWorkQueue();
+    }
+    return instance;
+}
+
+
+bool DobbyWorkQueue::runFor(const std::chrono::milliseconds &msecs)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->runFor(msecs);
+}
+
+void DobbyWorkQueue::exit()
+{
+   EXPECT_NE(impl, nullptr);
+
+    impl->exit();
+}
+
+bool DobbyWorkQueue::postWork(WorkFunc &&work)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->postWork(work);
+}

--- a/unit_tests/L1_testing/mocks/IDobbyStartState.h
+++ b/unit_tests/L1_testing/mocks/IDobbyStartState.h
@@ -1,0 +1,40 @@
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:
+*
+* Copyright 2023 Synamedia
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef IDOBBYSTARTSTATE_H
+#define IDOBBYSTARTSTATE_H
+
+#include <list>
+#include <string>
+
+#include <sys/mount.h>
+
+class IDobbyStartState {
+
+public:
+
+    IDobbyStartState();
+    ~IDobbyStartState();
+    virtual std::list<int> files() const = 0;
+};
+
+#endif // !defined(IDOBBYSTARTSTATE_H)
+
+
+

--- a/unit_tests/L1_testing/mocks/IIpcService.h
+++ b/unit_tests/L1_testing/mocks/IIpcService.h
@@ -48,45 +48,16 @@ static IIpcServiceImpl* impl;
 
 public:
 
-        static void setImpl(IIpcServiceImpl* newImpl)
-        {
-            impl = newImpl;
-        }
-
-        static bool isValid() {
-           return impl->isValid();
-        }
-        static std::shared_ptr<IAsyncReplyGetter> invokeMethod(const Method& method, const VariantList& args, int timeoutMs = -1) {
-            return impl->invokeMethod(method, args, timeoutMs);
-        }
-
-        static bool invokeMethod(const Method& method, const VariantList& args, VariantList& replyArgs, int timeoutMs = -1) {
-            return impl->invokeMethod(method, args, replyArgs, timeoutMs);
-        }
-
-        static bool emitSignal(const Signal& signal, const VariantList& args) {
-            return impl->emitSignal(signal, args);
-        }
-
-        static std::string registerMethodHandler(const Method& method, const MethodHandler& handler) {
-            return impl->registerMethodHandler(method, handler);
-        }
-
-        static std::string registerSignalHandler(const Signal& signal, const SignalHandler& handler) {
-            return impl->registerSignalHandler(signal, handler);
-        }
-
-        static bool unregisterHandler(const std::string& regId) {
-            return impl->unregisterHandler(regId);
-        }
-
-        static bool enableMonitor(const std::set<std::string>& matchRules, const MonitorHandler& handler) {
-            return impl->enableMonitor(matchRules, handler);
-        }
-
-        static void flush() {
-            impl->flush();
-        }
+        static void setImpl(IIpcServiceImpl* newImpl);
+        static bool isValid();
+        static std::shared_ptr<IAsyncReplyGetter> invokeMethod(const Method& method, const VariantList& args, int timeoutMs = -1);
+        static bool invokeMethod(const Method& method, const VariantList& args, VariantList& replyArgs, int timeoutMs = -1);
+        static bool emitSignal(const Signal& signal, const VariantList& args);
+        static std::string registerMethodHandler(const Method& method, const MethodHandler& handler);
+        static std::string registerSignalHandler(const Signal& signal, const SignalHandler& handler);
+        static bool unregisterHandler(const std::string& regId);
+        static bool enableMonitor(const std::set<std::string>& matchRules, const MonitorHandler& handler);
+        static void flush();
 };
 
 }

--- a/unit_tests/L1_testing/mocks/IIpcServiceMock.cpp
+++ b/unit_tests/L1_testing/mocks/IIpcServiceMock.cpp
@@ -1,0 +1,88 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "IIpcServiceMock.h"
+
+void AI_IPC::IIpcService::setImpl(IIpcServiceImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+bool AI_IPC::IIpcService::isValid()
+{
+   EXPECT_NE(impl, nullptr);
+
+   return impl->isValid();
+}
+
+std::shared_ptr<AI_IPC::IAsyncReplyGetter> AI_IPC::IIpcService::invokeMethod(const Method& method, const VariantList& args, int timeoutMs)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->invokeMethod(method, args, timeoutMs);
+}
+
+bool AI_IPC::IIpcService::invokeMethod(const Method& method, const VariantList& args, VariantList& replyArgs, int timeoutMs)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->invokeMethod(method, args, replyArgs, timeoutMs);
+}
+
+bool AI_IPC::IIpcService::emitSignal(const Signal& signal, const VariantList& args)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->emitSignal(signal, args);
+}
+
+std::string AI_IPC::IIpcService::registerMethodHandler(const Method& method, const MethodHandler& handler)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->registerMethodHandler(method, handler);
+}
+
+std::string AI_IPC::IIpcService::registerSignalHandler(const Signal& signal, const SignalHandler& handler)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->registerSignalHandler(signal, handler);
+}
+
+bool AI_IPC::IIpcService::unregisterHandler(const std::string& regId)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->unregisterHandler(regId);
+}
+
+bool AI_IPC::IIpcService::enableMonitor(const std::set<std::string>& matchRules, const MonitorHandler& handler)
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->enableMonitor(matchRules, handler);
+}
+
+void AI_IPC::IIpcService::flush()
+{
+   EXPECT_NE(impl, nullptr);
+
+    impl->flush();
+}
+

--- a/unit_tests/L1_testing/mocks/IpcCommon.h
+++ b/unit_tests/L1_testing/mocks/IpcCommon.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <functional>
 #include <memory>
+#include <gmock/gmock.h>
 
 namespace AI_IPC
 {
@@ -52,14 +53,27 @@ public:
 
     static bool sendReply(const VariantList& replyArgs)
     {
+        EXPECT_NE(impl, nullptr);
+
         return impl->sendReply(replyArgs);
     }
 
     static VariantList getMethodCallArguments()
     {
+        EXPECT_NE(impl, nullptr);
+
         return impl->getMethodCallArguments();
     }
 
+    static IAsyncReplySender* getInstance()
+    {
+        static IAsyncReplySender* instance = nullptr;
+        if(nullptr == instance)
+        {
+            instance = new IAsyncReplySender();
+        }
+        return instance;
+    }
 };
 
 

--- a/unit_tests/L1_testing/mocks/IpcFileDescriptor.h
+++ b/unit_tests/L1_testing/mocks/IpcFileDescriptor.h
@@ -37,37 +37,17 @@ protected:
     static IpcFileDescriptorApiImpl* impl;
 
 public:
-    IpcFileDescriptor(){}
-    IpcFileDescriptor(int fd){}
-    IpcFileDescriptor(const IpcFileDescriptor &other){}
-    IpcFileDescriptor &operator=(IpcFileDescriptor &&other){return *this;}
-    IpcFileDescriptor &operator=(const IpcFileDescriptor &other){return *this;}
-    ~IpcFileDescriptor(){}
+    IpcFileDescriptor();
+    IpcFileDescriptor(int fd);
+    IpcFileDescriptor(const IpcFileDescriptor &other);
+    IpcFileDescriptor &operator=(IpcFileDescriptor &&other);
+    IpcFileDescriptor &operator=(const IpcFileDescriptor &other);
+    ~IpcFileDescriptor();
 
-    static void setImpl(IpcFileDescriptorApiImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static IpcFileDescriptor* getInstance()
-    {
-        static IpcFileDescriptor* instance = nullptr;
-        if(nullptr == instance)
-        {
-            instance = new IpcFileDescriptor();
-        }
-        return instance;
-    }
-
-    bool isValid() const
-    {
-        return impl->isValid();
-    }
-
-    int fd() const
-    {
-        return impl->fd();
-    }
+    static void setImpl(IpcFileDescriptorApiImpl* newImpl);
+    static IpcFileDescriptor* getInstance();
+    bool isValid() const;
+    int fd() const;
 
 };
 }

--- a/unit_tests/L1_testing/mocks/IpcFileDescriptorMock.cpp
+++ b/unit_tests/L1_testing/mocks/IpcFileDescriptorMock.cpp
@@ -1,0 +1,76 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "IpcFileDescriptorMock.h"
+
+using::AI_IPC::IpcFileDescriptor;
+
+IpcFileDescriptor::IpcFileDescriptor()
+{
+}
+
+IpcFileDescriptor::IpcFileDescriptor(int fd)
+{
+}
+
+IpcFileDescriptor::IpcFileDescriptor(const IpcFileDescriptor &other)
+{
+}
+
+IpcFileDescriptor &IpcFileDescriptor::operator=(IpcFileDescriptor &&other)
+{
+    return *this;
+}
+
+IpcFileDescriptor &IpcFileDescriptor::operator=(const IpcFileDescriptor &other)
+{
+    return *this;
+}
+
+IpcFileDescriptor::~IpcFileDescriptor()
+{
+}
+
+void IpcFileDescriptor::setImpl(IpcFileDescriptorApiImpl* newImpl)
+{
+    impl = newImpl;
+}
+
+IpcFileDescriptor* IpcFileDescriptor::getInstance()
+{
+    static IpcFileDescriptor* instance = nullptr;
+    if(nullptr == instance)
+    {
+        instance = new IpcFileDescriptor();
+    }
+    return instance;
+}
+
+bool IpcFileDescriptor::isValid() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->isValid();
+}
+
+int IpcFileDescriptor::fd() const
+{
+   EXPECT_NE(impl, nullptr);
+
+    return impl->fd();
+}

--- a/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
+++ b/unit_tests/L1_testing/mocks/dobbymanager/DobbyManager.h
@@ -109,28 +109,15 @@ protected:
 
     static DobbyManagerImpl* impl;
 
-
 public:
     typedef std::function<void(int32_t cd, const ContainerId& id)> ContainerStartedFunc;
     typedef std::function<void(int32_t cd, const ContainerId& id, int32_t status)> ContainerStoppedFunc;
-    DobbyManager(){}
-    DobbyManager(std::shared_ptr<DobbyEnv>&, std::shared_ptr<DobbyUtils>&, std::shared_ptr<DobbyIPCUtils>&, const std::shared_ptr<const IDobbySettings>&, std::function<void(int, const ContainerId&)>&, std::function<void(int, const ContainerId&, int)>&) {}
-    ~DobbyManager(){}
+    DobbyManager();
+    DobbyManager(std::shared_ptr<DobbyEnv>&, std::shared_ptr<DobbyUtils>&, std::shared_ptr<DobbyIPCUtils>&, const std::shared_ptr<const IDobbySettings>&, std::function<void(int, const ContainerId&)>&, std::function<void(int, const ContainerId&, int)>&);
+    ~DobbyManager();
 
-    static void setImpl(DobbyManagerImpl* newImpl)
-    {
-        impl = newImpl;
-    }
-
-    static DobbyManager* getInstance()
-    {
-        static DobbyManager* instance = nullptr;
-        if(nullptr == instance)
-        {
-            instance = new DobbyManager();
-        }
-        return instance;
-    }
+    static void setImpl(DobbyManagerImpl* newImpl);
+    static DobbyManager* getInstance();
 
 #if defined(LEGACY_COMPONENTS)
 
@@ -139,20 +126,9 @@ public:
                                           const std::list<int>& files,
                                           const std::string& command,
                                           const std::string& displaySocket,
-                                          const std::vector<std::string>& envVars)
-    {
-        return impl->startContainerFromSpec(id, jsonSpec, files, command, displaySocket, envVars);
-    }
-
-    static std::string specOfContainer(int32_t cd)
-    {
-        return impl->specOfContainer(cd);
-    }
-
-    static bool createBundle(const ContainerId& id, const std::string& jsonSpec)
-    {
-        return impl->createBundle(id, jsonSpec);
-    }
+                                          const std::vector<std::string>& envVars);
+    static std::string specOfContainer(int32_t cd);
+    static bool createBundle(const ContainerId& id, const std::string& jsonSpec);
 #endif //defined(LEGACY_COMPONENTS)
 
     static int32_t startContainerFromBundle(const ContainerId& id,
@@ -160,55 +136,17 @@ public:
                                             const std::list<int>& files,
                                             const std::string& command,
                                             const std::string& displaySocket,
-                                            const std::vector<std::string>& envVars)
-    {
-        return impl->startContainerFromBundle(id, bundlePath, files, command, displaySocket, envVars);
-    }
-
-    static bool stopContainer(int32_t cd, bool withPrejudice)
-    {
-        return impl->stopContainer(cd, withPrejudice);
-    }
-
-    static bool pauseContainer(int32_t cd)
-    {
-        return impl->pauseContainer(cd);
-    }
-
-    static bool resumeContainer(int32_t cd)
-    {
-        return impl->resumeContainer(cd);
-    }
-
+                                            const std::vector<std::string>& envVars);
+    static bool stopContainer(int32_t cd, bool withPrejudice);
+    static bool pauseContainer(int32_t cd);
+    static bool resumeContainer(int32_t cd);
     static bool execInContainer(int32_t cd,
                                 const std::string& options,
-                                const std::string& command)
-    {
-        return impl->execInContainer(cd, options, command);
-    }
-
-    static std::list<std::pair<int32_t, ContainerId>> listContainers()
-    {
-        return impl->listContainers();
-    }
-
-    static int32_t stateOfContainer(int32_t cd)
-    {
-        return impl->stateOfContainer(cd);
-    }
-
-    static std::string statsOfContainer(int32_t cd)
-    {
-        return impl->statsOfContainer(cd);
-    }
-
-    static std::string ociConfigOfContainer(int32_t cd)
-    {
-        return impl->ociConfigOfContainer(cd);
-    }
-
-    ContainerStartedFunc mContainerStartedCb;
-    ContainerStoppedFunc mContainerStoppedCb;
+                                const std::string& command);
+    static std::list<std::pair<int32_t, ContainerId>> listContainers();
+    static int32_t stateOfContainer(int32_t cd);
+    static std::string statsOfContainer(int32_t cd);
+    static std::string ociConfigOfContainer(int32_t cd);
 
 };
 

--- a/unit_tests/L1_testing/mocks/rt_dobby_schema.c
+++ b/unit_tests/L1_testing/mocks/rt_dobby_schema.c
@@ -1,0 +1,42 @@
+/* If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Synamedia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+#include "rt_dobby_schema.h"
+
+void free_rt_dobby_schema_hooks (rt_dobby_schema_hooks *ptr)
+{
+}
+char *
+rt_dobby_schema_generate_json (const rt_dobby_schema *ptr, const struct parser_context *ctx, parser_error *err)
+{
+   char *json_buf = NULL;
+   return json_buf;
+}
+rt_dobby_schema *
+rt_dobby_schema_parse_file (const char *filename, const struct parser_context *ctx, parser_error *err)
+{
+   rt_dobby_schema *ptr = NULL;
+   return ptr;
+}
+void
+free_rt_dobby_schema (rt_dobby_schema *ptr)
+{
+}
+void free_rt_defs_plugins_legacy_plugins (rt_defs_plugins_legacy_plugins *ptr)
+{
+}

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/CMakeLists.txt
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/CMakeLists.txt
@@ -28,7 +28,27 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 add_library(DaemonDobbyManagerTest SHARED STATIC
             ../../../../daemon/lib/source/DobbyManager.cpp
-            ../../../../AppInfrastructure/Logging/source/Logging.cpp 
+            ../../../../AppInfrastructure/Logging/source/Logging.cpp
+            ../../mocks/DobbyBundleConfigMock.cpp
+            ../../mocks/DobbyRunCMock.cpp
+            ../../mocks/ContainerIdMock.cpp
+            ../../mocks/DobbyBundleMock.cpp
+            ../../mocks/DobbyConfigMock.cpp
+            ../../mocks/DobbyContainerMock.cpp
+            ../../mocks/DobbyEnvMock.cpp
+            ../../mocks/DobbyFileAccessFixerMock.cpp
+            ../../mocks/DobbyIPCUtilsMock.cpp
+            ../../mocks/DobbyLegacyPluginManagerMock.cpp
+            ../../mocks/DobbyRdkPluginManagerMock.cpp
+            ../../mocks/DobbyRdkPluginUtilsMock.cpp
+            ../../mocks/DobbyRootfsMock.cpp
+            ../../mocks/DobbySpecConfigMock.cpp
+            ../../mocks/DobbyStreamMock.cpp
+            ../../mocks/DobbyLoggerMock.cpp
+            ../../mocks/DobbyStatsMock.cpp
+            ../../mocks/rt_dobby_schema.c
+            ../../mocks/IpcFileDescriptorMock.cpp
+            ../../mocks/DobbyStartStateMock.cpp
             )
 
 target_include_directories(DaemonDobbyManagerTest

--- a/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
+++ b/unit_tests/L1_testing/tests/DobbyManagerTest/DaemonDobbyManagerTest.cpp
@@ -18,7 +18,10 @@
 */
 
 #include <gtest/gtest.h>
+#include "DobbyStreamMock.h"
 #include "DobbyRdkPluginUtilsMock.h"
+#include "DobbyLoggerMock.h"
+#include "DobbyRunCMock.h"
 #include "DobbyManager.h"
 #include "DobbyContainerMock.h"
 #include "DobbyRdkPluginManagerMock.h"
@@ -33,6 +36,10 @@
 #include "IDobbyUtilsMock.h"
 #include "IDobbyEnvMock.h"
 #include "IAsyncReplySenderMock.h"
+#include "ContainerIdMock.h"
+#include "DobbyFileAccessFixerMock.h"
+#include "DobbyLegacyPluginManagerMock.h"
+#include "DobbyStats.h"
 
 DobbyContainerImpl* DobbyContainer::impl = nullptr;
 DobbyRdkPluginManagerImpl* DobbyRdkPluginManager::impl = nullptr;
@@ -43,6 +50,15 @@ DobbyConfigImpl* DobbyConfig::impl = nullptr;
 DobbyBundleConfigImpl* DobbyBundleConfig::impl = nullptr;
 DobbyRdkPluginUtilsImpl* DobbyRdkPluginUtils::impl = nullptr;
 AI_IPC::IAsyncReplySenderApiImpl* AI_IPC::IAsyncReplySender::impl = nullptr;
+DobbyLegacyPluginManagerImpl* DobbyLegacyPluginManager::impl = nullptr;
+ContainerIdImpl* ContainerId::impl = nullptr;
+DobbyBufferStreamImpl *DobbyBufferStream::impl = nullptr;
+DobbyFileAccessFixerImpl *DobbyFileAccessFixer::impl = nullptr;
+DobbyRunCImpl *DobbyRunC::impl = nullptr;
+DobbyStatsImpl *DobbyStats::impl = nullptr;
+DobbyLoggerImpl *DobbyLogger::impl = nullptr;
+AI_IPC::IpcFileDescriptorApiImpl* AI_IPC::IpcFileDescriptor::impl = nullptr;
+DobbyStartStateImpl *DobbyStartState::impl = nullptr;
 using ::testing::NiceMock;
 
 class DaemonDobbyManagerTest : public ::testing::Test {

--- a/unit_tests/L1_testing/tests/DobbyTest/CMakeLists.txt
+++ b/unit_tests/L1_testing/tests/DobbyTest/CMakeLists.txt
@@ -30,6 +30,16 @@ include_directories(${GTEST_INCLUDE_DIRS})
 add_library(DaemonDobbyTests SHARED STATIC
             ../../../../daemon/lib/source/Dobby.cpp
             ../../../../AppInfrastructure/Logging/source/Logging.cpp
+            ../../mocks/ContainerIdMock.cpp
+            ../../mocks/DobbyContainerMock.cpp
+            ../../mocks/DobbyEnvMock.cpp
+            ../../mocks/DobbyIPCUtilsMock.cpp
+            ../../mocks/DobbyManagerMock.cpp
+            ../../mocks/DobbyTemplateMock.cpp
+            ../../mocks/DobbyUtilsMock.cpp
+            ../../mocks/DobbyWorkQueueMock.cpp
+            ../../mocks/IIpcServiceMock.cpp
+            ../../mocks/IpcFileDescriptorMock.cpp
             )
 
 


### PR DESCRIPTION
… mock files for DobbyManager

Refactoring for the Mock functions is moved to the cpp files from headers.

### Description
What does this PR change/fix and why?

If there is a corresponding JIRA ticket, please ensure it is in the title of the PR.

### Test Procedure
In the GitHub workflow, the L1 test is running and passing

### Type of Change
-Refactoring mock function definition.

### Requires Bitbake Recipe changes?
-None